### PR TITLE
chore: fix demo form data type

### DIFF
--- a/apps/demo-fixed-layout/src/nodes/default-form-meta.tsx
+++ b/apps/demo-fixed-layout/src/nodes/default-form-meta.tsx
@@ -3,7 +3,7 @@ import { FormRenderProps, FormMeta, ValidateTrigger } from '@flowgram.ai/fixed-l
 import { FlowNodeJSON } from '../typings';
 import { FormHeader, FormContent, FormInputs, FormOutputs } from '../form-components';
 
-export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON>) => (
+export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON['data']>) => (
   <>
     <FormHeader />
     <FormContent>

--- a/apps/demo-fixed-layout/src/nodes/default-form-meta.tsx
+++ b/apps/demo-fixed-layout/src/nodes/default-form-meta.tsx
@@ -13,7 +13,7 @@ export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON['data']>) => (
   </>
 );
 
-export const defaultFormMeta: FormMeta<FlowNodeJSON> = {
+export const defaultFormMeta: FormMeta<FlowNodeJSON['data']> = {
   render: renderForm,
   validateTrigger: ValidateTrigger.onChange,
   validate: {

--- a/apps/demo-fixed-layout/src/nodes/end/form-meta.tsx
+++ b/apps/demo-fixed-layout/src/nodes/end/form-meta.tsx
@@ -9,7 +9,7 @@ import {
 import { FlowNodeJSON, JsonSchema } from '../../typings';
 import { FormHeader, FormContent, FormOutputs, PropertiesEdit } from '../../form-components';
 
-export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON>) => (
+export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON['data']>) => (
   <>
     <FormHeader />
     <FormContent>

--- a/apps/demo-fixed-layout/src/nodes/end/form-meta.tsx
+++ b/apps/demo-fixed-layout/src/nodes/end/form-meta.tsx
@@ -29,7 +29,7 @@ export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON['data']>) => (
   </>
 );
 
-export const formMeta: FormMeta<FlowNodeJSON> = {
+export const formMeta: FormMeta<FlowNodeJSON['data']> = {
   render: renderForm,
   validateTrigger: ValidateTrigger.onChange,
   validate: {

--- a/apps/demo-fixed-layout/src/nodes/start/form-meta.tsx
+++ b/apps/demo-fixed-layout/src/nodes/start/form-meta.tsx
@@ -9,7 +9,7 @@ import {
 import { FlowNodeJSON, JsonSchema } from '../../typings';
 import { FormHeader, FormContent, FormOutputs, PropertiesEdit } from '../../form-components';
 
-export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON>) => (
+export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON['data']>) => (
   <>
     <FormHeader />
     <FormContent>

--- a/apps/demo-fixed-layout/src/nodes/start/form-meta.tsx
+++ b/apps/demo-fixed-layout/src/nodes/start/form-meta.tsx
@@ -29,7 +29,7 @@ export const renderForm = ({ form }: FormRenderProps<FlowNodeJSON['data']>) => (
   </>
 );
 
-export const formMeta: FormMeta<FlowNodeJSON> = {
+export const formMeta: FormMeta<FlowNodeJSON['data']> = {
   render: renderForm,
   validateTrigger: ValidateTrigger.onChange,
   validate: {


### PR DESCRIPTION
`FormRenderProps`'s generic type should be form's data type instead of `FlowNodeJSON`