### PR TITLE
docs: example and code sync

### DIFF
--- a/apps/docs/src/en/guide/advanced/interactive/shortcuts.mdx
+++ b/apps/docs/src/en/guide/advanced/interactive/shortcuts.mdx
@@ -5,9 +5,9 @@
 ```ts pure
 // Add to EditorProps
 {
-  shortcuts(shorcutsRegistry, ctx) {
+  shortcuts(shortcutsRegistry, ctx) {
       // Press command + a to select all nodes
-      shorcutsRegistry.addHandlers({
+      shortcutsRegistry.addHandlers({
         commandId: 'selectAll',
         shortcuts: ['meta a', 'ctrl a'],
         isEnabled: (...args) => true,

--- a/apps/docs/src/zh/guide/advanced/interactive/shortcuts.mdx
+++ b/apps/docs/src/zh/guide/advanced/interactive/shortcuts.mdx
@@ -5,9 +5,9 @@
 ```ts pure
 // 添加到 EditorProps
 {
-  shortcuts(shorcutsRegistry, ctx) {
+  shortcuts(shortcutsRegistry, ctx) {
       // 按住 cmmand + a，选中所有节点
-      shorcutsRegistry.addHandlers({
+      shortcutsRegistry.addHandlers({
         commandId: 'selectAll',
         shortcuts: ['meta a', 'ctrl a'],
         isEnabled: (...args) => true,


### PR DESCRIPTION
错误拼写，文档示例应该与源码一致