### PR TITLE
fix: resolve tooltip text-color abnormal

### DIFF
--- a/apps/docs/global.less
+++ b/apps/docs/global.less
@@ -79,9 +79,9 @@
   color: var(--text-color) !important;
 }
 
-.semi-tooltip-content {
-  color: black;
-}
+// .semi-tooltip-content {
+//   color: black;
+// }
 
 .dark {
   .invert-img {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/63c236ad-f86a-4066-965d-a2f4d85c2e08)
![image](https://github.com/user-attachments/assets/4b47c899-c6c1-472a-9ceb-5deb88395bde)

In official website documents, there are some abnormal text colors in both bright and dark modes. This pr is to solve this problem.

![image](https://github.com/user-attachments/assets/51a438f1-7934-4508-a570-f08579ad1d80)
![image](https://github.com/user-attachments/assets/ef97dfa9-c4a9-4da9-9924-8ea29247faed)
