### PR TITLE
fix: fix FieldArrayModel.swap state issue with doc example covered

### DIFF
--- a/apps/demo-node-form/src/components/field-wrapper.tsx
+++ b/apps/demo-node-form/src/components/field-wrapper.tsx
@@ -4,7 +4,7 @@ import './field-wrapper.css';
 
 interface FieldWrapperProps {
   required?: boolean;
-  title: string;
+  title?: string;
   children?: React.ReactNode;
   error?: string;
   note?: string;

--- a/apps/demo-node-form/src/constant.ts
+++ b/apps/demo-node-form/src/constant.ts
@@ -4,7 +4,7 @@ import './field-wrapper.css';
 
 interface FieldWrapperProps {
   required?: boolean;
-  title: string;
+  title?: string;
   children?: React.ReactNode;
   error?: string;
   note?: string;

--- a/apps/docs/components/node-form/array/index.css
+++ b/apps/docs/components/node-form/array/index.css
@@ -1,0 +1,7 @@
+.array-item-wrapper {
+  display: flex;
+  align-items: center;
+}
+.icon-button-popover {
+  padding: 6px 8px;
+}

--- a/apps/docs/components/node-form/array/node-registry.tsx
+++ b/apps/docs/components/node-form/array/node-registry.tsx
@@ -10,7 +10,7 @@ import {
   FieldArrayRenderProps,
 } from '@flowgram.ai/free-layout-editor';
 import { FieldWrapper } from '@flowgram.ai/demo-node-form';
-import { Input, Button, Tooltip, Popover } from '@douyinfe/semi-ui';
+import { Input, Button, Popover } from '@douyinfe/semi-ui';
 import { IconPlus, IconCrossCircleStroked, IconArrowDown } from '@douyinfe/semi-icons';
 import './index.css';
 import '../index.css';
@@ -22,7 +22,7 @@ export const render = () => (
       {({ field, fieldState }: FieldArrayRenderProps<string>) => (
         <FieldWrapper title={'My Array'}>
           {field.map((child, index) => (
-            <Field name={`${child.name}`} key={child.key}>
+            <Field name={child.name} key={child.key}>
               {({ field: childField, fieldState: childState }: FieldRenderProps<string>) => (
                 <FieldWrapper error={childState.errors?.[0]?.message}>
                   <div className="array-item-wrapper">
@@ -91,19 +91,17 @@ const formMeta: FormMeta<FormData> = {
       value.length > 8 ? 'max length exceeded: current length is ' + value.length : undefined,
   },
   effect: {
-    field1: [
+    'array.*': [
       {
-        event: DataEvent.onValueChange,
-        effect: ({ value }: EffectFuncProps<string, FormData>) => {
-          console.log('field1 value:', value);
+        event: DataEvent.onValueInit,
+        effect: ({ value, name }: EffectFuncProps<string, FormData>) => {
+          console.log(name + ' value init to ', value);
         },
       },
-    ],
-    field2: [
       {
         event: DataEvent.onValueChange,
-        effect: ({ value, form }: EffectFuncProps<string, FormData>) => {
-          form.setValueIn('field3', 'field2 value is ' + value);
+        effect: ({ value, name }: EffectFuncProps<string, FormData>) => {
+          console.log(name + ' value changed to ', value);
         },
       },
     ],

--- a/apps/docs/components/node-form/array/node-registry.tsx
+++ b/apps/docs/components/node-form/array/node-registry.tsx
@@ -1,0 +1,118 @@
+import {
+  DataEvent,
+  EffectFuncProps,
+  Field,
+  FieldRenderProps,
+  FormMeta,
+  ValidateTrigger,
+  WorkflowNodeRegistry,
+  FieldArray,
+  FieldArrayRenderProps,
+} from '@flowgram.ai/free-layout-editor';
+import { FieldWrapper } from '@flowgram.ai/demo-node-form';
+import { Input, Button, Tooltip, Popover } from '@douyinfe/semi-ui';
+import { IconPlus, IconCrossCircleStroked, IconArrowDown } from '@douyinfe/semi-icons';
+import './index.css';
+import '../index.css';
+
+export const render = () => (
+  <div className="demo-node-content">
+    <div className="demo-node-title">Array Examples</div>
+    <FieldArray name="array">
+      {({ field, fieldState }: FieldArrayRenderProps<string>) => (
+        <FieldWrapper title={'My Array'}>
+          {field.map((child, index) => (
+            <Field name={`${child.name}`} key={child.key}>
+              {({ field: childField, fieldState: childState }: FieldRenderProps<string>) => (
+                <FieldWrapper error={childState.errors?.[0]?.message}>
+                  <div className="array-item-wrapper">
+                    <Input {...childField} size={'small'} />
+                    {index < field.value!.length - 1 ? (
+                      <Popover
+                        content={'swap with next element'}
+                        className={'icon-button-popover'}
+                        showArrow
+                        position={'topLeft'}
+                      >
+                        <Button
+                          theme="borderless"
+                          size={'small'}
+                          icon={<IconArrowDown />}
+                          onClick={() => field.swap(index, index + 1)}
+                        />
+                      </Popover>
+                    ) : null}
+                    <Popover
+                      content={'delete current element'}
+                      className={'icon-button-popover'}
+                      showArrow
+                      position={'topLeft'}
+                    >
+                      <Button
+                        theme="borderless"
+                        size={'small'}
+                        icon={<IconCrossCircleStroked />}
+                        onClick={() => field.delete(index)}
+                      />
+                    </Popover>
+                  </div>
+                </FieldWrapper>
+              )}
+            </Field>
+          ))}
+          <div>
+            <Button
+              size={'small'}
+              theme="borderless"
+              icon={<IconPlus />}
+              onClick={() => field.append('default')}
+            >
+              Add
+            </Button>
+          </div>
+        </FieldWrapper>
+      )}
+    </FieldArray>
+  </div>
+);
+
+interface FormData {
+  array: string[];
+}
+
+const formMeta: FormMeta<FormData> = {
+  render,
+  validateTrigger: ValidateTrigger.onChange,
+  defaultValues: {
+    array: ['default'],
+  },
+  validate: {
+    'array.*': ({ value }) =>
+      value.length > 8 ? 'max length exceeded: current length is ' + value.length : undefined,
+  },
+  effect: {
+    field1: [
+      {
+        event: DataEvent.onValueChange,
+        effect: ({ value }: EffectFuncProps<string, FormData>) => {
+          console.log('field1 value:', value);
+        },
+      },
+    ],
+    field2: [
+      {
+        event: DataEvent.onValueChange,
+        effect: ({ value, form }: EffectFuncProps<string, FormData>) => {
+          form.setValueIn('field3', 'field2 value is ' + value);
+        },
+      },
+    ],
+  },
+};
+
+export const nodeRegistry: WorkflowNodeRegistry = {
+  type: 'custom',
+  meta: {},
+  defaultPorts: [{ type: 'output' }, { type: 'input' }],
+  formMeta,
+};

--- a/apps/docs/components/node-form/array/preview.tsx
+++ b/apps/docs/components/node-form/array/preview.tsx
@@ -1,0 +1,112 @@
+import {
+  DEFAULT_INITIAL_DATA,
+  defaultInitialDataTs,
+  fieldWrapperCss,
+  fieldWrapperTs,
+} from '@flowgram.ai/demo-node-form';
+
+import { Editor } from '../editor.tsx';
+import { PreviewEditor } from '../../preview-editor.tsx';
+import { nodeRegistry } from './node-registry.tsx';
+
+const nodeRegistryFile = {
+  code: `import {
+  DataEvent,
+  EffectFuncProps,
+  Field,
+  FieldRenderProps,
+  FormMeta,
+  ValidateTrigger,
+  WorkflowNodeRegistry,
+} from '@flowgram.ai/free-layout-editor';
+import { FieldWrapper } from '@flowgram.ai/demo-node-form';
+import { Input } from '@douyinfe/semi-ui';
+import '../index.css';
+
+const render = () => (
+  <div className="demo-node-content">
+    <div className="demo-node-title">Effect Examples</div>
+    <Field name="field1">
+      {({ field }: FieldRenderProps<string>) => (
+        <FieldWrapper
+          title="Basic effect"
+          note={'The following field will console.log field value on value change'}
+        >
+          <Input size={'small'} {...field} />
+        </FieldWrapper>
+      )}
+    </Field>
+
+    <Field name="field2">
+      {({ field }: FieldRenderProps<string>) => (
+        <FieldWrapper
+          title="Control other fields"
+          note={'The following field will change Field 3 value on value change'}
+        >
+          <Input size={'small'} {...field} />
+        </FieldWrapper>
+      )}
+    </Field>
+    <Field name="field3">
+      {({ field }: FieldRenderProps<string>) => (
+        <FieldWrapper title="Controlled by other fields">
+          <Input size={'small'} {...field} />
+        </FieldWrapper>
+      )}
+    </Field>
+  </div>
+);
+
+interface FormData {
+  field1: string;
+  field2: string;
+  field3: string;
+}
+
+const formMeta: FormMeta<FormData> = {
+  render,
+  validateTrigger: ValidateTrigger.onChange,
+  effect: {
+    field1: [
+      {
+        event: DataEvent.onValueChange,
+        effect: ({ value }: EffectFuncProps<string, FormData>) => {
+          console.log('field1 value:', value);
+        },
+      },
+    ],
+    field2: [
+      {
+        event: DataEvent.onValueChange,
+        effect: ({ value, form }: EffectFuncProps<string, FormData>) => {
+          form.setValueIn('field3', 'field2 value is ' + value);
+        },
+      },
+    ],
+  },
+};
+
+export const nodeRegistry: WorkflowNodeRegistry = {
+  type: 'custom',
+  meta: {},
+  defaultPorts: [{ type: 'output' }, { type: 'input' }],
+  formMeta,
+};
+
+`,
+  active: true,
+};
+
+export const NodeFormArrayPreview = () => {
+  const files = {
+    'node-registry.tsx': nodeRegistryFile,
+    'initial-data.ts': { code: defaultInitialDataTs, active: true },
+    'field-wrapper.tsx': { code: fieldWrapperTs, active: true },
+    'field-wrapper.css': { code: fieldWrapperCss, active: true },
+  };
+  return (
+    <PreviewEditor files={files} previewStyle={{ height: 500 }} editorStyle={{ height: 500 }}>
+      <Editor registry={nodeRegistry} initialData={DEFAULT_INITIAL_DATA} />
+    </PreviewEditor>
+  );
+};

--- a/apps/docs/components/node-form/array/preview.tsx
+++ b/apps/docs/components/node-form/array/preview.tsx
@@ -18,68 +18,102 @@ const nodeRegistryFile = {
   FormMeta,
   ValidateTrigger,
   WorkflowNodeRegistry,
+  FieldArray,
+  FieldArrayRenderProps,
 } from '@flowgram.ai/free-layout-editor';
 import { FieldWrapper } from '@flowgram.ai/demo-node-form';
-import { Input } from '@douyinfe/semi-ui';
+import { Input, Button, Popover } from '@douyinfe/semi-ui';
+import { IconPlus, IconCrossCircleStroked, IconArrowDown } from '@douyinfe/semi-icons';
+import './index.css';
 import '../index.css';
 
-const render = () => (
+export const render = () => (
   <div className="demo-node-content">
-    <div className="demo-node-title">Effect Examples</div>
-    <Field name="field1">
-      {({ field }: FieldRenderProps<string>) => (
-        <FieldWrapper
-          title="Basic effect"
-          note={'The following field will console.log field value on value change'}
-        >
-          <Input size={'small'} {...field} />
+    <div className="demo-node-title">Array Examples</div>
+    <FieldArray name="array">
+      {({ field, fieldState }: FieldArrayRenderProps<string>) => (
+        <FieldWrapper title={'My Array'}>
+          {field.map((child, index) => (
+            <Field name={child.name} key={child.key}>
+              {({ field: childField, fieldState: childState }: FieldRenderProps<string>) => (
+                <FieldWrapper error={childState.errors?.[0]?.message}>
+                  <div className="array-item-wrapper">
+                    <Input {...childField} size={'small'} />
+                    {index < field.value!.length - 1 ? (
+                      <Popover
+                        content={'swap with next element'}
+                        className={'icon-button-popover'}
+                        showArrow
+                        position={'topLeft'}
+                      >
+                        <Button
+                          theme="borderless"
+                          size={'small'}
+                          icon={<IconArrowDown />}
+                          onClick={() => field.swap(index, index + 1)}
+                        />
+                      </Popover>
+                    ) : null}
+                    <Popover
+                      content={'delete current element'}
+                      className={'icon-button-popover'}
+                      showArrow
+                      position={'topLeft'}
+                    >
+                      <Button
+                        theme="borderless"
+                        size={'small'}
+                        icon={<IconCrossCircleStroked />}
+                        onClick={() => field.delete(index)}
+                      />
+                    </Popover>
+                  </div>
+                </FieldWrapper>
+              )}
+            </Field>
+          ))}
+          <div>
+            <Button
+              size={'small'}
+              theme="borderless"
+              icon={<IconPlus />}
+              onClick={() => field.append('default')}
+            >
+              Add
+            </Button>
+          </div>
         </FieldWrapper>
       )}
-    </Field>
-
-    <Field name="field2">
-      {({ field }: FieldRenderProps<string>) => (
-        <FieldWrapper
-          title="Control other fields"
-          note={'The following field will change Field 3 value on value change'}
-        >
-          <Input size={'small'} {...field} />
-        </FieldWrapper>
-      )}
-    </Field>
-    <Field name="field3">
-      {({ field }: FieldRenderProps<string>) => (
-        <FieldWrapper title="Controlled by other fields">
-          <Input size={'small'} {...field} />
-        </FieldWrapper>
-      )}
-    </Field>
+    </FieldArray>
   </div>
 );
 
 interface FormData {
-  field1: string;
-  field2: string;
-  field3: string;
+  array: string[];
 }
 
 const formMeta: FormMeta<FormData> = {
   render,
   validateTrigger: ValidateTrigger.onChange,
+  defaultValues: {
+    array: ['default'],
+  },
+  validate: {
+    'array.*': ({ value }) =>
+      value.length > 8 ? 'max length exceeded: current length is ' + value.length : undefined,
+  },
   effect: {
-    field1: [
+    'array.*': [
       {
-        event: DataEvent.onValueChange,
-        effect: ({ value }: EffectFuncProps<string, FormData>) => {
-          console.log('field1 value:', value);
+        event: DataEvent.onValueInit,
+        effect: ({ value, name }: EffectFuncProps<string, FormData>) => {
+          console.log(name + ' value init to ', value);
         },
       },
-    ],
-    field2: [
       {
         event: DataEvent.onValueChange,
-        effect: ({ value, form }: EffectFuncProps<string, FormData>) => {
-          form.setValueIn('field3', 'field2 value is ' + value);
+        effect: ({ value, name }: EffectFuncProps<string, FormData>) => {
+          console.log(name + ' value changed to ', value);
         },
       },
     ],

--- a/apps/docs/src/zh/examples/node-form/_meta.json
+++ b/apps/docs/src/zh/examples/node-form/_meta.json
@@ -1,4 +1,5 @@
 [
   "basic",
-  "effect"
+  "effect",
+  "array"
 ]

--- a/apps/docs/src/zh/examples/node-form/array.mdx
+++ b/apps/docs/src/zh/examples/node-form/array.mdx
@@ -1,0 +1,10 @@
+---
+outline: false
+---
+
+
+# 数组
+
+import { NodeFormArrayPreview } from '../../../../components/node-form/array/preview';
+
+<NodeFormArrayPreview />

--- a/packages/node-engine/form/__tests__/field-array-model.test.ts
+++ b/packages/node-engine/form/__tests__/field-array-model.test.ts
@@ -4,6 +4,8 @@ import { Errors, ValidateTrigger, Warnings } from '@/types';
 import { FormModel } from '@/core/form-model';
 import { type FieldArrayModel } from '@/core/field-array-model';
 
+import { FeedbackLevel } from '../src/types';
+
 describe('FormArrayModel', () => {
   let formModel = new FormModel();
   describe('children', () => {
@@ -580,53 +582,171 @@ describe('FormArrayModel', () => {
 
     it('can swap from 0 to middle index', () => {
       const arrayField = formModel.createFieldArray('arr');
-      arrayField!.append('a');
-      arrayField!.append('b');
-      arrayField!.append('c');
+      const a = arrayField!.append('a');
+      const b = arrayField!.append('b');
+      const c = arrayField!.append('c');
 
       formModel.init({});
+
+      a.state.errors = {
+        'arr.0': [{ name: 'arr.0', message: 'err0', level: FeedbackLevel.Error }],
+      };
+      b.state.errors = {
+        'arr.1': [{ name: 'arr.1', message: 'err1', level: FeedbackLevel.Error }],
+      };
 
       expect(formModel.values).toEqual({ arr: ['a', 'b', 'c'] });
       arrayField.swap(0, 1);
       expect(formModel.values).toEqual({ arr: ['b', 'a', 'c'] });
+      expect(formModel.getField('arr.0').state.errors).toEqual({
+        'arr.0': [{ name: 'arr.0', message: 'err1', level: FeedbackLevel.Error }],
+      });
+      expect(formModel.getField('arr.1').state.errors).toEqual({
+        'arr.1': [{ name: 'arr.1', message: 'err0', level: FeedbackLevel.Error }],
+      });
     });
 
     it('can swap from 0 to last index', () => {
       const arrayField = formModel.createFieldArray('arr');
-      arrayField!.append('a');
-      arrayField!.append('b');
-      arrayField!.append('c');
+      const a = arrayField!.append('a');
+      const b = arrayField!.append('b');
+      const c = arrayField!.append('c');
 
       formModel.init({});
+
+      a.state.errors = {
+        'arr.0': [{ name: 'arr.0', message: 'err0', level: FeedbackLevel.Error }],
+      };
+      c.state.errors = {
+        'arr.2': [{ name: 'arr.2', message: 'err2', level: FeedbackLevel.Error }],
+      };
 
       expect(formModel.values).toEqual({ arr: ['a', 'b', 'c'] });
       arrayField.swap(0, 2);
       expect(formModel.values).toEqual({ arr: ['c', 'b', 'a'] });
+      expect(formModel.getField('arr.0').state.errors).toEqual({
+        'arr.0': [{ name: 'arr.0', message: 'err2', level: FeedbackLevel.Error }],
+      });
+      expect(formModel.getField('arr.2').state.errors).toEqual({
+        'arr.2': [{ name: 'arr.2', message: 'err0', level: FeedbackLevel.Error }],
+      });
     });
     it('can swap from middle index to last index', () => {
       const arrayField = formModel.createFieldArray('arr');
-      arrayField!.append('a');
-      arrayField!.append('b');
-      arrayField!.append('c');
+      const a = arrayField!.append('a');
+      const b = arrayField!.append('b');
+      const c = arrayField!.append('c');
 
       formModel.init({});
+
+      b.state.errors = {
+        'arr.1': [{ name: 'arr.1', message: 'err1', level: FeedbackLevel.Error }],
+      };
+      c.state.errors = {
+        'arr.2': [{ name: 'arr.2', message: 'err2', level: FeedbackLevel.Error }],
+      };
 
       expect(formModel.values).toEqual({ arr: ['a', 'b', 'c'] });
       arrayField.swap(1, 2);
       expect(formModel.values).toEqual({ arr: ['a', 'c', 'b'] });
+      expect(formModel.getField('arr.1').state.errors).toEqual({
+        'arr.1': [{ name: 'arr.1', message: 'err2', level: FeedbackLevel.Error }],
+      });
+      expect(formModel.getField('arr.2').state.errors).toEqual({
+        'arr.2': [{ name: 'arr.2', message: 'err1', level: FeedbackLevel.Error }],
+      });
     });
     it('can swap from middle index to another middle index', () => {
       const arrayField = formModel.createFieldArray('arr');
       arrayField!.append('a');
-      arrayField!.append('b');
-      arrayField!.append('c');
+      const b = arrayField!.append('b');
+      const c = arrayField!.append('c');
       arrayField!.append('d');
 
       formModel.init({});
 
+      b.state.errors = {
+        'arr.1': [{ name: 'arr.1', message: 'err1', level: FeedbackLevel.Error }],
+      };
+      c.state.errors = {
+        'arr.2': [{ name: 'arr.2', message: 'err2', level: FeedbackLevel.Error }],
+      };
+
       expect(formModel.values).toEqual({ arr: ['a', 'b', 'c', 'd'] });
       arrayField.swap(1, 2);
       expect(formModel.values).toEqual({ arr: ['a', 'c', 'b', 'd'] });
+      expect(formModel.getField('arr.1').state.errors).toEqual({
+        'arr.1': [{ name: 'arr.1', message: 'err2', level: FeedbackLevel.Error }],
+      });
+      expect(formModel.getField('arr.2').state.errors).toEqual({
+        'arr.2': [{ name: 'arr.2', message: 'err1', level: FeedbackLevel.Error }],
+      });
+    });
+
+    it('can swap for nested array', () => {
+      const arrayField = formModel.createFieldArray('arr');
+      const a = arrayField!.append({ x: 'x0', y: 'y0' });
+      const b = arrayField!.append({ x: 'x1', y: 'y1' });
+      const ax = formModel.createField('arr.0.x');
+      const ay = formModel.createField('arr.0.y');
+      const bx = formModel.createField('arr.1.x');
+      const by = formModel.createField('arr.1.y');
+
+      formModel.init({});
+
+      ax.state.errors = {
+        'arr.0.x': [{ name: 'arr.0.x', message: 'err0x', level: FeedbackLevel.Error }],
+      };
+      bx.state.errors = {
+        'arr.1.x': [{ name: 'arr.1.x', message: 'err1x', level: FeedbackLevel.Error }],
+      };
+
+      expect(formModel.values).toEqual({
+        arr: [
+          { x: 'x0', y: 'y0' },
+          { x: 'x1', y: 'y1' },
+        ],
+      });
+      arrayField.swap(0, 1);
+      expect(formModel.values).toEqual({
+        arr: [
+          { x: 'x1', y: 'y1' },
+          { x: 'x0', y: 'y0' },
+        ],
+      });
+      expect(formModel.getField('arr.0.x').state.errors).toEqual({
+        'arr.0.x': [{ name: 'arr.0.x', message: 'err1x', level: FeedbackLevel.Error }],
+      });
+      expect(formModel.getField('arr.1.x').state.errors).toEqual({
+        'arr.1.x': [{ name: 'arr.1.x', message: 'err0x', level: FeedbackLevel.Error }],
+      });
+
+      // assert form.state.errors
+      expect(formModel.state.errors['arr.0.x']).toEqual([
+        { name: 'arr.0.x', message: 'err1x', level: FeedbackLevel.Error },
+      ]);
+      expect(formModel.state.errors['arr.1.x']).toEqual([
+        { name: 'arr.1.x', message: 'err0x', level: FeedbackLevel.Error },
+      ]);
+    });
+
+    it('should have correct form.state.errors after swapping invalid field with valid field', () => {
+      const arrayField = formModel.createFieldArray('arr');
+      const a = arrayField!.append('a');
+      const b = arrayField!.append('b');
+      arrayField!.append('c');
+
+      formModel.init({});
+
+      b.state.errors = {
+        'arr.1': [{ name: 'arr.1', message: 'err1', level: FeedbackLevel.Error }],
+      };
+
+      arrayField.swap(0, 1);
+      expect(formModel.getField('arr.0').state.errors).toEqual({
+        'arr.0': [{ name: 'arr.0', message: 'err1', level: FeedbackLevel.Error }],
+      });
+      expect(formModel.getField('arr.1').state.errors).toEqual(undefined);
     });
 
     it('should trigger array effect and child effect', () => {

--- a/packages/node-engine/form/src/core/utils.ts
+++ b/packages/node-engine/form/src/core/utils.ts
@@ -5,7 +5,7 @@ import { Errors, Feedback, OnFormValuesChangePayload, ValidateTrigger, Warnings 
 import { Path } from './path';
 
 export function updateFeedbacksName(feedbacks: Feedback<any>[], name: string) {
-  return feedbacks.map((f) => ({
+  return (feedbacks || []).map((f) => ({
     ...f,
     name,
   }));
@@ -91,7 +91,7 @@ export namespace FieldEventUtils {
   ) {
     const { name: changedName, options } = payload;
 
-    if (options?.action === 'array-splice') {
+    if (options?.action === 'array-splice' || options?.action === 'array-swap') {
       // const splicedIndexes = options?.indexes || [];
       //
       // const splicedPaths = splicedIndexes.map(index => new Path(changedName).concat(index));
@@ -109,7 +109,7 @@ export namespace FieldEventUtils {
       //   return false;
       // }
 
-      // splice 情况下仅触发数组field的校验
+      // splice 和 swap 都属于数组跟级别的变更，仅需触发数组field的校验, 无需校验子项
       return fieldName === changedName;
     }
 

--- a/packages/node-engine/form/src/types/form.ts
+++ b/packages/node-engine/form/src/types/form.ts
@@ -108,7 +108,7 @@ export interface CreateFormReturn<TValues> {
 }
 
 export interface OnFormValuesChangeOptions {
-  action?: 'array-append' | 'array-splice';
+  action?: 'array-append' | 'array-splice' | 'array-swap';
   indexes?: number[];
 }
 

--- a/packages/node-engine/node/src/form-model-v2.ts
+++ b/packages/node-engine/node/src/form-model-v2.ts
@@ -135,6 +135,10 @@ export class FormModelV2 extends FormModel implements Disposable {
     return this.node.getNodeRegistry().formMeta;
   }
 
+  get values() {
+    return this.nativeFormModel?.values;
+  }
+
   protected _feedbacks: FormFeedback[] = [];
 
   get feedbacks(): FormFeedback[] {


### PR DESCRIPTION
**1. bugfix: error state is not swapped when using `ArrayField.swap`** 


before:
![20250320153239_rec_](https://github.com/user-attachments/assets/95cc4404-5793-4bc4-8123-8c59e2914498)


after:
![20250320152822_rec_](https://github.com/user-attachments/assets/598c998e-02cf-4a3c-99a4-ef15df97a005)


**2. add `get values() `method to `FormModel`**

