### PR TITLE
fix: fix multiple layer undefined pattern matching

### DIFF
--- a/packages/node-engine/form/__tests__/form-model.test.ts
+++ b/packages/node-engine/form/__tests__/form-model.test.ts
@@ -77,6 +77,46 @@ describe('FormModel', () => {
       // 4. assert field state has been bubbled to its parent
       expect(bField.state?.errors?.['a.b.x']?.[0].message).toEqual('error');
     });
+    it('should run validate if multiple patterns match', async () => {
+      const mockValidate1 = vi.fn();
+      const mockValidate2 = vi.fn();
+      formModel.init({
+        validate: {
+          'a.b.*': mockValidate1,
+          'a.b.x': mockValidate2,
+        },
+      });
+
+      const bField = formModel.createField('a.b');
+      const xField = formModel.createField('a.b.x');
+
+      formModel.setValueIn('a.b', { x: 1, y: 2 });
+
+      formModel.validate();
+
+      expect(mockValidate1).toHaveBeenCalledTimes(2);
+      expect(mockValidate2).toHaveBeenCalledTimes(1);
+    });
+    it('should run validate correctly if multiple patterns match but multiple layer empty value exist', async () => {
+      const mockValidate1 = vi.fn();
+      const mockValidate2 = vi.fn();
+      formModel.init({
+        validate: {
+          'a.*.x': mockValidate1,
+          'a.b.x': mockValidate2,
+        },
+      });
+
+      const bField = formModel.createField('a.b');
+      const xField = formModel.createField('a.b.x');
+
+      formModel.setValueIn('a', {});
+
+      formModel.validate();
+
+      expect(mockValidate1).toHaveBeenCalledTimes(0);
+      expect(mockValidate2).toHaveBeenCalledTimes(1);
+    });
     it('should correctly set form errors state when field does not exist', async () => {
       formModel.init({
         validate: {

--- a/packages/node-engine/form/__tests__/glob.test.ts
+++ b/packages/node-engine/form/__tests__/glob.test.ts
@@ -277,9 +277,17 @@ describe('glob', () => {
       const obj = { a: { b: { c: 1 } } };
       expect(Glob.findMatchPathsWithEmptyValue(obj, 'a.b.c')).toEqual(['a.b.c']);
     });
-    it('return empty path array if path does not exists ', () => {
+    it('return original path array if no * and value is empty on multiple layers', () => {
+      const obj = { a: {} };
+      expect(Glob.findMatchPathsWithEmptyValue(obj, 'a.b.c')).toEqual(['a.b.c']);
+    });
+    it('return original path array if no * and value is empty on multiple layers', () => {
+      const obj = { a: { b: {} } };
+      expect(Glob.findMatchPathsWithEmptyValue(obj, 'a.x.y')).toEqual(['a.x.y']);
+    });
+    it('return array with original path even if path does not exists, but the original path does not contain * ', () => {
       const obj = { a: { b: { c: 1 } } };
-      expect(Glob.findMatchPathsWithEmptyValue(obj, 'a.b.c.d')).toEqual([]);
+      expect(Glob.findMatchPathsWithEmptyValue(obj, 'a.b.c.d')).toEqual(['a.b.c.d']);
     });
     it('return original path array if no * and path related value is undefined in object', () => {
       const obj = { a: { b: { c: {} } } };

--- a/packages/node-engine/form/src/utils/glob.ts
+++ b/packages/node-engine/form/src/utils/glob.ts
@@ -222,6 +222,9 @@ export namespace Glob {
    * @param pattern
    */
   export function findMatchPathsWithEmptyValue(obj: any, pattern: string): string[] {
+    if (!pattern.includes('*')) {
+      return [pattern];
+    }
     return findMatchPaths(obj, pattern, true);
   }
 


### PR DESCRIPTION
This fix is for validate rule pattern matching when path value is multiple layer `undefiend`, for example,
if data is `{a:{}}`, validate rule on  `a.b.c` will not be executed before this fix.
