### PR TITLE
fix: transact no operation should not throw error

### DIFF
--- a/packages/canvas-engine/document/__tests__/services/flow-operation-base-service.test.ts
+++ b/packages/canvas-engine/document/__tests__/services/flow-operation-base-service.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { baseMockAddNode, baseMockAddBranch } from '../flow.mock';
 import { createDocumentContainer } from '../flow-document-container.mock';
-import { FlowOperationBaseService, FlowDocument, OperationType } from '../../src';
+import { FlowOperationBaseService, FlowDocument, OperationType, OnNodeMoveEvent } from '../../src';
 
 describe('flow-operation-base-service', () => {
   let container = createDocumentContainer();
@@ -246,5 +246,18 @@ describe('flow-operation-base-service', () => {
     expect(child.next?.id).toEqual('dynamicSplit_0');
     expect(child.hidden).toEqual(true);
     expect(fn).toBeCalledTimes(1);
+  });
+
+  it('moveNode should fire event', () => {
+    let event: OnNodeMoveEvent;
+
+    flowOperationService.onNodeMove((e) => {
+      event = e;
+      expect(event.node.id === 'noop_0');
+      expect(event.fromIndex === 1);
+      expect(event.toParent.id === 'block_0');
+      expect(event.toIndex === 1);
+    });
+    flowOperationService.moveNode('noop_0', { parent: 'block_0' });
   });
 });

--- a/packages/common/history/__tests__/history-service.test.ts
+++ b/packages/common/history/__tests__/history-service.test.ts
@@ -128,7 +128,8 @@ describe('history-service', () => {
   });
 
   it('transact no operation', async () => {
-    expect(() => historyService.transact(() => {})).toThrowError('no operation be pushed');
+    historyService.transact(() => {});
+    expect(historyService.canUndo()).toEqual(false);
   });
 
   it('clear should clear all', () => {

--- a/packages/common/history/src/history/history-service.ts
+++ b/packages/common/history/src/history/history-service.ts
@@ -91,11 +91,10 @@ export class HistoryService implements IHistoryService {
     if (!stackOperation) {
       return;
     }
-    if (stackOperation.getOperations().length === 0) {
-      throw new Error('no operation be pushed');
+    if (stackOperation.getOperations().length !== 0) {
+      this._pushStackOperation(stackOperation);
     }
 
-    this._pushStackOperation(stackOperation);
     this._transactOperation = null;
     this._transacting = false;
   }


### PR DESCRIPTION
### Changes
1. If no operations are pushed when executing a transaction, no exception is thrown. 
2. Add a test for move node