### PR TITLE
fix: npx @flowgram.ai/form-materials cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,4 +130,5 @@ Enjoy it!
 
 - Issues: [Issues](https://github.com/bytedance/flowgram.ai/issues)
 - Lark: Scan the QR code below with [Register Feishu](https://www.feishu.cn/en/) to join our FlowGram user group.
-<img src="./apps/docs/src/public/lark-group.png"/>
+
+<img src="./apps/docs/src/public/lark-group.png" width="200"/>

--- a/packages/materials/form-materials/bin/index.js
+++ b/packages/materials/form-materials/bin/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import chalk from 'chalk';
 import { Command } from 'commander';
 import inquirer from 'inquirer';


### PR DESCRIPTION
When run `npx @flowgram.ai/form-materials`, it returns error:
<img width="975" alt="image" src="https://github.com/user-attachments/assets/57daa461-57e8-4591-9fab-d261850a906b" />


Fix it by adding `#!/usr/bin/env node` to first line of scripts