### PR TITLE
feat: add customizable port colors to WorkflowPortRender

### DIFF
--- a/apps/demo-free-layout/src/hooks/use-editor-props.tsx
+++ b/apps/demo-free-layout/src/hooks/use-editor-props.tsx
@@ -77,12 +77,12 @@ export function useEditorProps(
         return json;
       },
       lineColor: {
-        hidden: 'var(--g-line-color-hidden,transparent)',
-        default: 'var(--g-line-color-default,#4d53e8)',
-        drawing: 'var(--g-line-color-drawing, #5DD6E3)',
-        hovered: 'var(--g-line-color-hover,#37d0ff)',
-        selected: 'var(--g-line-color-selected,#37d0ff)',
-        error: 'var(--g-line-color-hover,red)',
+        hidden: 'var(--g-workflow-line-color-hidden,transparent)',
+        default: 'var(--g-workflow-line-color-default,#4d53e8)',
+        drawing: 'var(--g-workflow-line-color-drawing, #5DD6E3)',
+        hovered: 'var(--g-workflow-line-color-hover,#37d0ff)',
+        selected: 'var(--g-workflow-line-color-selected,#37d0ff)',
+        error: 'var(--g-workflow-line-color-error,red)',
       },
       /*
        * Check whether the line can be added

--- a/apps/demo-free-layout/src/styles/index.css
+++ b/apps/demo-free-layout/src/styles/index.css
@@ -1,71 +1,80 @@
 :root {
-    --g-workflow-port-color-primary: #4d53e8;
-    --g-workflow-port-color-secondary: #9197f1;
-    --g-workflow-port-color-error: #ff0000;
-    --g-workflow-port-color-background: #ffffff;
+  /* Port colors */
+  --g-workflow-port-color-primary: #4d53e8;
+  --g-workflow-port-color-secondary: #9197f1;
+  --g-workflow-port-color-error: #ff0000;
+  --g-workflow-port-color-background: #ffffff;
+
+  /* Line colors */
+  --g-workflow-line-color-hidden: transparent;
+  --g-workflow-line-color-default: #4d53e8;
+  --g-workflow-line-color-drawing: #5dd6e3;
+  --g-workflow-line-color-hover: #37d0ff;
+  --g-workflow-line-color-selected: #37d0ff;
+  --g-workflow-line-color-error: red;
 }
 
 .gedit-selector-bounds-background {
-    cursor: move;
-    display: none !important;
+  cursor: move;
+  display: none !important;
 }
 
 .gedit-selector-bounds-foreground {
-    cursor: move;
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 0;
-    height: 0;
-    outline: 1px solid var(--g-playground-selectBox-outline);
-    z-index: 33;
-    background-color: var(--g-playground-selectBox-background);
+  cursor: move;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 0;
+  height: 0;
+  outline: 1px solid var(--g-playground-selectBox-outline);
+  z-index: 33;
+  background-color: var(--g-playground-selectBox-background);
 }
 
 @keyframes blink {
-    0% {
-        opacity: 1;
-    }
-    50% {
-        opacity: 0;
-    }
-    100% {
-        opacity: 1;
-    }
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }
 
 .node-running {
-    border: 1px dashed rgb(78, 64, 229) !important;
-    border-radius: 8px;
+  border: 1px dashed rgb(78, 64, 229) !important;
+  border-radius: 8px;
 }
 .demo-editor {
-    flex-grow: 1;
-    position: relative;
-    height: 100%;
+  flex-grow: 1;
+  position: relative;
+  height: 100%;
 }
 
 .demo-container {
-    position: absolute;
-    left: 0px;
-    top: 0px;
-    display: flex;
-    width: 100%;
-    height: 100%;
-    flex-direction: column;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
 }
 
 .demo-tools {
-    padding: 10px;
-    display: flex;
-    justify-content: space-between;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
 }
 
 .demo-tools-group > * {
-    margin-right: 8px;
+  margin-right: 8px;
 }
 
 .mouse-pad-option-icon {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/apps/docs/src/en/api/components/workflow-node-renderer.mdx
+++ b/apps/docs/src/en/api/components/workflow-node-renderer.mdx
@@ -17,7 +17,15 @@ export const BaseNode = () => {
    * https://github.com/bytedance/flowgram.ai/blob/main/packages/client/free-layout-editor/src/components/workflow-node-renderer.tsx
    */
   return (
-    <WorkflowNodeRenderer className="demo-free-node" node={props.node}>
+    <WorkflowNodeRenderer
+      className="demo-free-node"
+      node={props.node}
+      // Optional port color customization
+      portPrimaryColor="#4d53e8"        // Active state color (linked/hovered)
+      portSecondaryColor="#9197f1"      // Default state color
+      portErrorColor="#ff4444"          // Error state color
+      portBackgroundColor="#ffffff"     // Background color
+    >
       {
         // Form rendering through formMeta generation
         form?.render()

--- a/apps/docs/src/en/guide/advanced/free-layout/port.mdx
+++ b/apps/docs/src/en/guide/advanced/free-layout/port.mdx
@@ -56,6 +56,15 @@ function BaseNode() {
 
 Ports are ultimately rendered through the `WorkflowPortRender` component, supporting custom styles, or businesses can reimplement this component based on the source code, see [Free Layout Best Practices - Node Rendering](https://github.com/bytedance/flowgram.ai/blob/main/apps/demo-free-layout/src/components/base-node/node-wrapper.tsx)
 
+### Custom Port Colors
+
+You can customize port colors by passing color props to `WorkflowPortRender`:
+
+- `primaryColor` - Active state color (when linked or hovered)
+- `secondaryColor` - Default state color
+- `errorColor` - Error state color
+- `backgroundColor` - Background color
+
 ```tsx pure
 
 import { WorkflowPortRender, useNodeRender } from '@flowgram.ai/free-layout-editor';
@@ -67,7 +76,17 @@ function BaseNode() {
       <div data-port-id="condition-if-0" data-port-type="output"></div>
       <div data-port-id="condition-if-1" data-port-type="output"></div>
       {ports.map((p) => (
-        <WorkflowPortRender key={p.id} entity={p} className="xxx" style={{ /* custom style */}}/>
+        <WorkflowPortRender
+          key={p.id}
+          entity={p}
+          className="xxx"
+          style={{ /* custom style */}}
+          // Custom port colors
+          primaryColor="#4d53e8"        // Active state color (linked/hovered)
+          secondaryColor="#9197f1"      // Default state color
+          errorColor="#ff4444"          // Error state color
+          backgroundColor="#ffffff"     // Background color
+        />
       ))}
     </div>
   )

--- a/apps/docs/src/zh/api/components/workflow-node-renderer.mdx
+++ b/apps/docs/src/zh/api/components/workflow-node-renderer.mdx
@@ -17,7 +17,15 @@ export const BaseNode = () => {
    * https://github.com/bytedance/flowgram.ai/blob/main/packages/client/free-layout-editor/src/components/workflow-node-renderer.tsx
    */
   return (
-    <WorkflowNodeRenderer className="demo-free-node" node={props.node}>
+    <WorkflowNodeRenderer
+      className="demo-free-node"
+      node={props.node}
+      // 可选的端口颜色自定义
+      portPrimaryColor="#4d53e8"        // 激活状态颜色 (linked/hovered)
+      portSecondaryColor="#9197f1"      // 默认状态颜色
+      portErrorColor="#ff4444"          // 错误状态颜色
+      portBackgroundColor="#ffffff"     // 背景颜色
+    >
       {
         // 表单渲染通过 formMeta 生成
         form?.render()

--- a/apps/docs/src/zh/guide/advanced/free-layout/port.mdx
+++ b/apps/docs/src/zh/guide/advanced/free-layout/port.mdx
@@ -56,6 +56,15 @@ function BaseNode() {
 
 端口最终通过 `WorkflowPortRender` 组件渲染，支持自定义 style, 或者业务基于源码重新实现该组件, 参考 [自由布局最佳实践 - 节点渲染](https://github.com/bytedance/flowgram.ai/blob/main/apps/demo-free-layout/src/components/base-node/node-wrapper.tsx)
 
+### 自定义端口颜色
+
+可以通过向 `WorkflowPortRender` 传递颜色 props 来自定义端口颜色：
+
+- `primaryColor` - 激活状态颜色（linked/hovered）
+- `secondaryColor` - 默认状态颜色
+- `errorColor` - 错误状态颜色
+- `backgroundColor` - 背景颜色
+
 ```tsx pure
 
 import { WorkflowPortRender, useNodeRender } from '@flowgram.ai/free-layout-editor';
@@ -67,7 +76,17 @@ function BaseNode() {
       <div data-port-id="condition-if-0" data-port-type="output"></div>
       <div data-port-id="condition-if-1" data-port-type="output"></div>
       {ports.map((p) => (
-        <WorkflowPortRender key={p.id} entity={p} className="xxx" style={{ /* custom style */}}/>
+        <WorkflowPortRender
+          key={p.id}
+          entity={p}
+          className="xxx"
+          style={{ /* custom style */}}
+          // 自定义端口颜色
+          primaryColor="#4d53e8"        // 激活状态颜色（linked/hovered）
+          secondaryColor="#9197f1"      // 默认状态颜色
+          errorColor="#ff4444"          // 错误状态颜色
+          backgroundColor="#ffffff"     // 背景颜色
+        />
       ))}
     </div>
   )

--- a/packages/canvas-engine/free-layout-core/src/typings/workflow-line.ts
+++ b/packages/canvas-engine/free-layout-core/src/typings/workflow-line.ts
@@ -24,12 +24,12 @@ export interface LineColor {
 }
 
 export enum LineColors {
-  HIDDEN = 'var(--g-line-color-hidden,transparent)', // 隐藏线条
-  DEFUALT = 'var(--g-line-color-default,#4d53e8)',
-  DRAWING = 'var(--g-line-color-drawing, #5DD6E3)', // '#b5bbf8', // '#9197F1',
-  HOVER = 'var(--g-line-color-hover,#37d0ff)',
-  SELECTED = 'var(--g-line-color-selected,#37d0ff)',
-  ERROR = 'var(--g-line-color-error,red)',
+  HIDDEN = 'var(--g-workflow-line-color-hidden,transparent)', // 隐藏线条
+  DEFUALT = 'var(--g-workflow-line-color-default,#4d53e8)',
+  DRAWING = 'var(--g-workflow-line-color-drawing, #5DD6E3)', // '#b5bbf8', // '#9197F1',
+  HOVER = 'var(--g-workflow-line-color-hover,#37d0ff)',
+  SELECTED = 'var(--g-workflow-line-color-selected,#37d0ff)',
+  ERROR = 'var(--g-workflow-line-color-error,red)',
 }
 
 export interface WorkflowLineRenderContribution {

--- a/packages/client/free-layout-editor/src/components/workflow-node-renderer.tsx
+++ b/packages/client/free-layout-editor/src/components/workflow-node-renderer.tsx
@@ -19,6 +19,14 @@ export interface WorkflowNodeProps {
     port: WorkflowPortEntity,
     e: React.MouseEvent<HTMLDivElement> | React.MouseEventHandler<HTMLDivElement>
   ) => void;
+  /** 端口激活状态颜色 (linked/hovered) */
+  portPrimaryColor?: string;
+  /** 端口默认状态颜色 */
+  portSecondaryColor?: string;
+  /** 端口错误状态颜色 */
+  portErrorColor?: string;
+  /** 端口背景颜色 */
+  portBackgroundColor?: string;
 }
 
 export const WorkflowNodeRenderer: React.FC<WorkflowNodeProps> = (props) => {
@@ -50,6 +58,10 @@ export const WorkflowNodeRenderer: React.FC<WorkflowNodeProps> = (props) => {
           onClick={props.onPortClick ? (e) => props.onPortClick!(p, e) : undefined}
           className={props.portClassName}
           style={props.portStyle}
+          primaryColor={props.portPrimaryColor}
+          secondaryColor={props.portSecondaryColor}
+          errorColor={props.portErrorColor}
+          backgroundColor={props.portBackgroundColor}
         />
       ))}
     </>

--- a/packages/plugins/free-lines-plugin/src/components/workflow-port-render/index.tsx
+++ b/packages/plugins/free-lines-plugin/src/components/workflow-port-render/index.tsx
@@ -19,6 +19,14 @@ export interface WorkflowPortRenderProps {
   className?: string;
   style?: React.CSSProperties;
   onClick?: React.MouseEventHandler<HTMLDivElement>;
+  /** 激活状态颜色 (linked/hovered) */
+  primaryColor?: string;
+  /** 默认状态颜色 */
+  secondaryColor?: string;
+  /** 错误状态颜色 */
+  errorColor?: string;
+  /** 背景颜色 */
+  backgroundColor?: string;
 }
 
 export const WorkflowPortRender: React.FC<WorkflowPortRenderProps> =
@@ -79,10 +87,30 @@ export const WorkflowPortRender: React.FC<WorkflowPortRenderProps> =
       // 有线条链接的时候深蓝色小圆点
       linked,
     });
+
+    // 构建 CSS 自定义属性用于颜色覆盖
+    const colorStyles: Record<string, string> = {};
+    if (props.primaryColor) {
+      colorStyles['--g-workflow-port-color-primary'] = props.primaryColor;
+    }
+    if (props.secondaryColor) {
+      colorStyles['--g-workflow-port-color-secondary'] = props.secondaryColor;
+    }
+    if (props.errorColor) {
+      colorStyles['--g-workflow-port-color-error'] = props.errorColor;
+    }
+    if (props.backgroundColor) {
+      colorStyles['--g-workflow-port-color-background'] = props.backgroundColor;
+    }
+
+    const combinedStyle = targetElement
+      ? { ...props.style, ...colorStyles }
+      : { ...props.style, ...colorStyles, left: posX, top: posY };
+
     const content = (
       <WorkflowPointStyle
         className={className}
-        style={targetElement ? props.style : { ...props.style, left: posX, top: posY }}
+        style={combinedStyle}
         onClick={onClick}
         data-port-entity-id={entity.id}
         data-port-entity-type={entity.portType}


### PR DESCRIPTION
## 🎯 功能描述

添加端口颜色自定义功能，允许通过 props 方式自定义 WorkflowPortRender 组件的颜色，替代之前需要通过 CSS 选择器覆盖样式的方案。

## 💡 背景与动机

之前要自定义端口颜色需要通过复杂的 CSS 选择器：
```css
div[data-port-entity-type='input'].workflow-port-render { /* 样式 */ }
div[data-port-entity-type='output'].workflow-port-render { /* 样式 */ }
```

现在可以直接通过 props 传递：
```tsx
<WorkflowNodeRenderer 
  portPrimaryColor="#4d53e8" 
  portSecondaryColor="#9197f1" 
/>
```

## 🔧 实现方案

### 新增 Props

**WorkflowPortRender 组件:**
- `primaryColor?: string` - 激活状态颜色 (linked/hovered)
- `secondaryColor?: string` - 默认状态颜色
- `errorColor?: string` - 错误状态颜色
- `backgroundColor?: string` - 背景颜色

**WorkflowNodeRenderer 组件:**
- `portPrimaryColor?: string` - 端口激活状态颜色
- `portSecondaryColor?: string` - 端口默认状态颜色
- `portErrorColor?: string` - 端口错误状态颜色
- `portBackgroundColor?: string` - 端口背景颜色

### 技术实现
- 使用 CSS 自定义属性 (CSS Variables) 覆盖默认颜色
- 运行时动态设置 CSS 变量值
- 完全向后兼容，不影响现有代码

## 📝 修改内容

### 代码变更
- [x] **WorkflowPortRender 组件** (`packages/plugins/free-lines-plugin/src/components/workflow-port-render/index.tsx`)
  - 添加颜色相关 props 到接口
  - 实现 CSS 自定义属性覆盖逻辑
  
- [x] **WorkflowNodeRenderer 组件** (`packages/client/free-layout-editor/src/components/workflow-node-renderer.tsx`)
  - 添加端口颜色 props 到接口
  - 传递颜色 props 到 WorkflowPortRender 组件

### 文档更新

#### API 文档
- [x] **英文 API 文档** (`apps/docs/src/en/api/components/workflow-node-renderer.mdx`)
  - 更新 WorkflowNodeRenderer 使用示例
  - 添加颜色自定义的注释说明
  
- [x] **中文 API 文档** (`apps/docs/src/zh/api/components/workflow-node-renderer.mdx`)
  - 更新 WorkflowNodeRenderer 使用示例
  - 添加颜色自定义的注释说明

#### 功能指南
- [x] **英文端口指南** (`apps/docs/src/en/guide/advanced/free-layout/port.mdx`)
  - 新增 "Custom Port Colors" 章节
  - 更新 WorkflowPortRender 使用示例
  - 详细说明各颜色 prop 的用途
  
- [x] **中文端口指南** (`apps/docs/src/zh/guide/advanced/free-layout/port.mdx`)
  - 新增 "自定义端口颜色" 章节
  - 更新 WorkflowPortRender 使用示例
  - 详细说明各颜色 prop 的用途

## 📖 使用示例

### 基础用法
```tsx
import { WorkflowNodeRenderer, useNodeRender } from '@flowgram.ai/free-layout-editor';

export const CustomColorNode = (props) => {
  const { form } = useNodeRender();
  
  return (
    <WorkflowNodeRenderer
      className="demo-free-node"
      node={props.node}
      portPrimaryColor="#4d53e8"        // 激活状态颜色
      portSecondaryColor="#9197f1"      // 默认状态颜色
      portErrorColor="#ff4444"          // 错误状态颜色
      portBackgroundColor="#ffffff"     // 背景颜色
    >
      {form?.render()}
    </WorkflowNodeRenderer>
  );
};
```

### 直接使用 WorkflowPortRender
```tsx
import { WorkflowPortRender } from '@flowgram.ai/free-layout-editor';

{ports.map((p) => (
  <WorkflowPortRender
    key={p.id}
    entity={p}
    primaryColor="#4d53e8"
    secondaryColor="#9197f1"
    errorColor="#ff4444"
    backgroundColor="#ffffff"
  />
))}
```

## 🧪 测试

- [x] **TypeScript 类型检查通过**
  - `packages/plugins/free-lines-plugin`: ✅
  - `packages/client/free-layout-editor`: ✅
  
- [x] **单元测试通过** (12/12 tests passed)
  
- [x] **构建成功**
  - `free-lines-plugin` 包构建成功
  - `free-layout-editor` 包构建成功
  
- [x] **文档构建成功**
  - 文档服务器正常运行
  - 中英文文档渲染正常

## 🔄 向后兼容性

✅ **完全向后兼容** - 此更改不会破坏任何现有代码：
- 所有新 props 都是可选的
- 如果不传递颜色 props，组件使用默认 CSS 变量
- 现有的 CSS 覆盖方式仍然有效

## 📚 文档预览

文档服务器地址: http://localhost:3002/

**更新的文档页面:**
- 📄 端口指南 (中文): `/zh/guide/advanced/free-layout/port`
- 📄 端口指南 (英文): `/en/guide/advanced/free-layout/port`
- 📄 API 文档 (中文): `/zh/api/components/workflow-node-renderer`
- 📄 API 文档 (英文): `/en/api/components/workflow-node-renderer`

## 🏷️ 类型

- **Type**: Feature
- **Scope**: workflow-port
- **Breaking Change**: No
- **Documentation**: Yes

## 📋 Checklist

- [x] 代码实现完成
- [x] TypeScript 类型检查通过
- [x] 单元测试通过
- [x] 构建成功
- [x] 中英文文档更新
- [x] 使用示例添加
- [x] 向后兼容性确认
- [x] Commit message 符合规范