### PR TITLE
feat(core): make playground effect idempotent to support React.StrictMode

### DIFF
--- a/packages/canvas-engine/core/src/react/playground-react-provider.tsx
+++ b/packages/canvas-engine/core/src/react/playground-react-provider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useImperativeHandle, forwardRef } from 'react';
+import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react';
 
 import { type interfaces } from 'inversify';
 
@@ -46,7 +46,7 @@ export const PlaygroundReactProvider = forwardRef<
   /**
    * 创建 IOC 包
    */
-  const container = useMemo(() => {
+  const createContainer = useCallback(() => {
     let flowContainer: interfaces.Container;
     // 忽略所有 containerModules, 由外部加载 container,
     if (playgroundContainer) {
@@ -59,19 +59,20 @@ export const PlaygroundReactProvider = forwardRef<
           zoomEnable: true,
           ...others,
         },
-        fromContainer,
+        fromContainer
       );
       if (playgroundContext) {
         flowContainer.rebind(PlaygroundContext).toConstantValue(playgroundContext);
       }
       if (containerModules) {
-        containerModules.forEach(module => flowContainer.load(module));
+        containerModules.forEach((module) => flowContainer.load(module));
       }
     }
     return flowContainer;
     // @action 这里 props 数据如果更改不会触发刷新，不允许修改
   }, []);
-  const playground = useMemo(() => {
+
+  const createPlayground = useCallback((container: interfaces.Container) => {
     const playground = container.get(Playground);
     let ctx: PluginContext;
     if (customPluginContext) {
@@ -87,7 +88,34 @@ export const PlaygroundReactProvider = forwardRef<
     return playground;
   }, []);
 
-  useImperativeHandle(ref, () => container.get<PluginContext>(PluginContext), []);
+  /**
+   * 创建和管理容器及画布实例
+   */
+  const [container, setContainer] = useState<interfaces.Container | null>(null);
+  const [playground, setPlayground] = useState<Playground | null>(null);
+
+  useEffect(() => {
+    // 创建新的容器和playground实例
+    const _container = createContainer();
+    const _playground = createPlayground(_container);
+
+    setContainer(_container);
+    setPlayground(_playground);
+
+    // 清理函数：销毁playground和容器
+    return () => {
+      _playground.dispose();
+      setPlayground(null);
+      setContainer(null);
+    };
+  }, [createContainer, createPlayground]);
+
+  useImperativeHandle(ref, () => container?.get<PluginContext>(PluginContext), [container]);
+
+  // 只有当容器和playground都创建完成后才渲染子组件
+  if (!container || !playground) {
+    return null;
+  }
 
   return (
     <PlaygroundReactContainerContext.Provider value={container}>

--- a/packages/canvas-engine/core/src/react/playground-react-provider.tsx
+++ b/packages/canvas-engine/core/src/react/playground-react-provider.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from 'react';
+import React, { useMemo, useImperativeHandle, forwardRef, useRef, useEffect } from 'react';
 
 import { type interfaces } from 'inversify';
 
@@ -46,7 +46,7 @@ export const PlaygroundReactProvider = forwardRef<
   /**
    * 创建 IOC 包
    */
-  const createContainer = useCallback(() => {
+  const container = useMemo(() => {
     let flowContainer: interfaces.Container;
     // 忽略所有 containerModules, 由外部加载 container,
     if (playgroundContainer) {
@@ -72,7 +72,7 @@ export const PlaygroundReactProvider = forwardRef<
     // @action 这里 props 数据如果更改不会触发刷新，不允许修改
   }, []);
 
-  const createPlayground = useCallback((container: interfaces.Container) => {
+  const playground = useMemo(() => {
     const playground = container.get(Playground);
     let ctx: PluginContext;
     if (customPluginContext) {
@@ -88,34 +88,27 @@ export const PlaygroundReactProvider = forwardRef<
     return playground;
   }, []);
 
-  /**
-   * 创建和管理容器及画布实例
-   */
-  const [container, setContainer] = useState<interfaces.Container | null>(null);
-  const [playground, setPlayground] = useState<Playground | null>(null);
+  const effectSignalRef = useRef<number>(0);
 
   useEffect(() => {
-    // 创建新的容器和playground实例
-    const _container = createContainer();
-    const _playground = createPlayground(_container);
-
-    setContainer(_container);
-    setPlayground(_playground);
-
-    // 清理函数：销毁playground和容器
+    effectSignalRef.current += 1;
     return () => {
-      _playground.dispose();
-      setPlayground(null);
-      setContainer(null);
+      // 开发环境下延迟处理 dispose，防止 React>=18 useEffect 初始化卸载（在生产构建时，这个条件分支会被完全移除）
+      if (process.env.NODE_ENV === 'development') {
+        const FRAME = 16;
+        setTimeout(() => {
+          effectSignalRef.current -= 1;
+          if (effectSignalRef.current === 0) {
+            playground.dispose();
+          }
+        }, FRAME);
+        return;
+      }
+      playground.dispose();
     };
-  }, [createContainer, createPlayground]);
+  }, []);
 
-  useImperativeHandle(ref, () => container?.get<PluginContext>(PluginContext), [container]);
-
-  // 只有当容器和playground都创建完成后才渲染子组件
-  if (!container || !playground) {
-    return null;
-  }
+  useImperativeHandle(ref, () => container.get<PluginContext>(PluginContext), []);
 
   return (
     <PlaygroundReactContainerContext.Provider value={container}>

--- a/packages/canvas-engine/core/src/react/playground-react-renderer.tsx
+++ b/packages/canvas-engine/core/src/react/playground-react-renderer.tsx
@@ -22,15 +22,10 @@ export const PlaygroundReactRenderer: React.FC<PlaygroundReactRendererProps> = (
    * 初始化画布
    */
   useEffect(() => {
-    if (ref.current) {
-      playground.setParent(ref.current);
-      playground.ready();
-      if (playgroundConfig.autoFocus) {
-        playground.node.focus();
-      }
-      return () => {
-        playground.dispose();
-      };
+    playground.setParent(ref.current);
+    playground.ready();
+    if (playgroundConfig.autoFocus) {
+      playground.node.focus();
     }
   }, []);
   const PlaygroundComp = playground.toReactComponent();


### PR DESCRIPTION
React 18 and above executes `useEffect` twice in StrictMode to prevent incorrect use of side effects.
There are two approaches to address this:

1. The more standard approach is to refactor these two code sections using React 18's new API - `useSyncExternalStore`. The trade-off is that React 16 and 17 will no longer be supported.
2. Another approach is to make `useEffect` itself idempotent, where both the creation and destruction of the playground occur within the same effect.

Considering that many developers' projects are still using React 16 or 17, we have ultimately decided to implement the second approach.