### PR TITLE
feat(materials): add className prop to JsonSchemaEditor

### DIFF
--- a/packages/materials/form-materials/src/components/json-schema-editor/index.tsx
+++ b/packages/materials/form-materials/src/components/json-schema-editor/index.tsx
@@ -38,6 +38,7 @@ export function JsonSchemaEditor(props: {
   value?: IJsonSchema;
   onChange?: (value: IJsonSchema) => void;
   config?: ConfigType;
+  className?: string;
 }) {
   const { value = { type: 'object' }, config = {}, onChange: onChangeProps } = props;
   const { propertyList, onAddProperty, onRemoveProperty, onEditProperty } = usePropertiesEdit(
@@ -46,7 +47,7 @@ export function JsonSchemaEditor(props: {
   );
 
   return (
-    <UIContainer>
+    <UIContainer className={props.className}>
       <UIProperties>
         {propertyList.map((_property, index) => (
           <PropertyEdit
@@ -63,7 +64,12 @@ export function JsonSchemaEditor(props: {
           />
         ))}
       </UIProperties>
-      <Button size="small" style={{ marginTop: 10 }} icon={<IconPlus />} onClick={onAddProperty}>
+      <Button
+        size="small"
+        style={{ marginTop: 10, marginLeft: 16 }}
+        icon={<IconPlus />}
+        onClick={onAddProperty}
+      >
         {config?.addButtonText ?? 'Add'}
       </Button>
     </UIContainer>


### PR DESCRIPTION
add className prop to JsonSchemaEditor and adjust button styling

1.增加className配置项 2.调整“添加按钮”左边距

[
![Snipaste_2025-06-24_11-26-52](https://github.com/user-attachments/assets/a802531c-8f1a-4293-8b94-56482d65e4dd)
![Snipaste_2025-06-24_11-27-42](https://github.com/user-attachments/assets/c1d0c717-b3a5-4e03-956e-848a7214ec31)

