### PR TITLE
fix: 修复Loop节点端口位置更新延迟问题 (#430)

### DIFF
--- a/packages/plugins/free-container-plugin/src/sub-canvas/hooks/use-sync-node-render-size.ts
+++ b/packages/plugins/free-container-plugin/src/sub-canvas/hooks/use-sync-node-render-size.ts
@@ -1,6 +1,7 @@
 import { useLayoutEffect } from 'react';
 
 import { useCurrentEntity } from '@flowgram.ai/free-layout-core';
+import { FlowNodeTransformData } from '@flowgram.ai/document';
 
 import { NodeSize } from './use-node-size';
 
@@ -11,7 +12,49 @@ export const useSyncNodeRenderSize = (nodeSize?: NodeSize) => {
     if (!nodeSize) {
       return;
     }
+
+    // 更新DOM样式
     node.renderData.node.style.width = nodeSize.width + 'px';
     node.renderData.node.style.height = nodeSize.height + 'px';
+
+    // 添加延迟确保DOM渲染完成后再更新数据
+    // Add delay to ensure DOM rendering is complete before updating data
+    requestAnimationFrame(() => {
+      setTimeout(() => {
+        if (!node.disposed) {
+          // 触发transform数据更新，确保连线系统能感知到容器大小变化
+          // Trigger transform data update to ensure line system can detect container size changes
+          const transform = node.getData<FlowNodeTransformData>(FlowNodeTransformData);
+          if (transform) {
+            // 强制刷新bounds缓存并触发变化事件
+            // Force refresh bounds cache and trigger change event
+            node.clearMemoGlobal();
+            node.clearMemoLocal();
+
+            // 更新size数据以保持同步
+            // Update size data to keep in sync
+            transform.update({ size: { width: nodeSize.width, height: nodeSize.height } });
+
+            // 触发变化事件
+            // Trigger change event
+            transform.fireChange();
+
+            // 递归清理并更新所有父节点缓存，确保嵌套容器也能正确更新
+            // Recursively clear and update all parent node caches for nested containers
+            let parentNode = node.parent;
+            while (parentNode) {
+              parentNode.clearMemoGlobal();
+              parentNode.clearMemoLocal();
+              const parentTransform =
+                parentNode.getData<FlowNodeTransformData>(FlowNodeTransformData);
+              if (parentTransform) {
+                parentTransform.fireChange();
+              }
+              parentNode = parentNode.parent;
+            }
+          }
+        }
+      }, 16); // 16ms延迟确保至少一帧渲染完成
+    });
   }, [nodeSize?.width, nodeSize?.height]);
 };


### PR DESCRIPTION
# 修复：Loop节点端口位置更新延迟问题

## 🐛 问题描述
在Loop容器中添加或删除子节点时，连接的线条端口位置不会立即更新，用户必须手动拖动节点才能刷新端口位置。

## 🔧 根本原因
问题由DOM渲染时序引起：在容器大小变化后，端口位置计算时DOM尚未完全渲染完成。

## ✨ 解决方案
优化了 `useSyncNodeRenderSize` hook，通过以下方式解决：
- 添加 `requestAnimationFrame + setTimeout` 延迟机制，确保DOM渲染完成
- 递归清理容器节点和所有父节点的memo缓存
- 与DOM变化同步更新size数据
- 触发完整的变化事件链传播

## 📁 修改文件
- `packages/plugins/free-container-plugin/src/sub-canvas/hooks/use-sync-node-render-size.ts`

## ✅ 测试验证
- ✅ 包测试通过
- ✅ 代码风格检查通过 (`rush lint`)
- ✅ 构建验证完成 (`rush build`)
- ✅ demo应用手动测试验证

## 🎯 修复效果
修复后，在Loop容器中添加/删除节点时，端口位置会自动实时更新，无需手动操作。

## 📸 测试场景
1. 创建Loop节点
2. 连接其他节点到Loop节点
3. 在Loop内部添加/删除子节点
4. 观察连线端口位置是否实时更新

## 🔗 相关Issue
修复Loop节点端口更新不及时的用户体验问题。

---

**类型**: 🐛 Bug修复  
**影响范围**: Loop容器节点端口位置更新  
**向后兼容**: ✅ 完全兼容  
**测试覆盖**: ✅ 已验证