### PR TITLE
feat(client): autoLayout add disableFitView option

### DIFF
--- a/packages/client/free-layout-editor/src/hooks/use-auto-layout.ts
+++ b/packages/client/free-layout-editor/src/hooks/use-auto-layout.ts
@@ -20,7 +20,11 @@ import { TransformData } from '@flowgram.ai/editor';
 
 type AutoLayoutResetFn = () => void;
 
-type AutoLayoutFn = (options?: LayoutOptions) => Promise<AutoLayoutResetFn>;
+export type AutoLayoutOptions = LayoutOptions & {
+  disableFitView?: boolean;
+};
+
+type AutoLayoutFn = (options?: AutoLayoutOptions) => Promise<AutoLayoutResetFn>;
 
 type UseAutoLayout = () => AutoLayoutFn;
 
@@ -124,10 +128,15 @@ export const useAutoLayout: UseAutoLayout = () => {
     [document, playground]
   );
   const autoLayout: AutoLayoutFn = useCallback(
-    async (options?: LayoutOptions): Promise<AutoLayoutResetFn> => {
-      handleFitView();
+    async (options: AutoLayoutOptions = {}): Promise<AutoLayoutResetFn> => {
+      const { disableFitView } = options;
+      if (disableFitView !== true) {
+        handleFitView();
+      }
       const resetFn: AutoLayoutResetFn = await applyLayout(options);
-      handleFitView();
+      if (disableFitView !== true) {
+        handleFitView();
+      }
       return resetFn;
     },
     [applyLayout]

--- a/packages/client/free-layout-editor/src/hooks/use-playground-tools.ts
+++ b/packages/client/free-layout-editor/src/hooks/use-playground-tools.ts
@@ -16,10 +16,9 @@ import {
   usePlayground,
   useService,
 } from '@flowgram.ai/free-layout-core';
-import { LayoutOptions } from '@flowgram.ai/free-auto-layout-plugin';
 import { EditorState } from '@flowgram.ai/editor';
 
-import { useAutoLayout } from './use-auto-layout';
+import { useAutoLayout, type AutoLayoutOptions } from './use-auto-layout';
 
 interface SetCursorStateCallbackEvent {
   isPressingSpaceBar: boolean;
@@ -31,7 +30,7 @@ export interface PlaygroundTools {
   zoomin: (easing?: boolean) => void;
   zoomout: (easing?: boolean) => void;
   fitView: (easing?: boolean) => void;
-  autoLayout: (options?: LayoutOptions) => Promise<() => void>;
+  autoLayout: (options?: AutoLayoutOptions) => Promise<() => void>;
   /**
    * 切换线条
    */

--- a/packages/plugins/free-auto-layout-plugin/src/layout/type.ts
+++ b/packages/plugins/free-auto-layout-plugin/src/layout/type.ts
@@ -71,7 +71,7 @@ export interface LayoutParams {
 
 export interface LayoutOptions {
   getFollowNode?: GetFollowNode;
-  enableAnimation: boolean;
+  enableAnimation?: boolean;
 }
 
 export interface LayoutConfig {


### PR DESCRIPTION
    await tools.autoLayout({
      disableFitView: true,
    });


```ts
export const AutoLayout = () => {
  const tools = usePlaygroundTools();
  const playground = usePlayground();
  const autoLayout = useCallback(async () => {
    await tools.autoLayout({
      disableFitView: true,
    });
  }, [tools]);

  return (
    <Tooltip content={'Auto Layout'}>
      <IconButton
        disabled={playground.config.readonly}
        type="tertiary"
        theme="borderless"
        onClick={autoLayout}
        icon={IconAutoLayout}
      />
    </Tooltip>
  );
};
```