### PR TITLE
docs(runtime): runtime navigation collapsed by default

### DIFF
--- a/apps/docs/src/en/guide/_meta.json
+++ b/apps/docs/src/en/guide/_meta.json
@@ -19,6 +19,7 @@
   {
     "type": "dir",
     "name": "runtime",
-    "label": "Runtime (WIP)"
+    "label": "Runtime (WIP)",
+    "collapsed": true
   }
 ]

--- a/apps/docs/src/zh/guide/_meta.json
+++ b/apps/docs/src/zh/guide/_meta.json
@@ -19,6 +19,7 @@
   {
     "type": "dir",
     "name": "runtime",
-    "label": "运行时 (WIP)"
+    "label": "运行时接入 (WIP)",
+    "collapsed": true
   }
 ]


### PR DESCRIPTION
## Preview

<img width="1912" height="980" alt="截屏2025-07-18 11 28 31" src="https://github.com/user-attachments/assets/eb5fb903-53b4-4e2c-8fc8-0af05e942940" />
