### PR TITLE
refactor(minimap-plugin): use throttle to improve the performance of minimap, api inactiveDebounceTime -> inactiveThrottleTime

### DIFF
--- a/apps/demo-fixed-layout-simple/src/components/minimap.tsx
+++ b/apps/demo-fixed-layout-simple/src/components/minimap.tsx
@@ -3,38 +3,33 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/fixed-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
-export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: 16,
-        bottom: 51,
-        zIndex: 100,
-        width: 198,
+export const Minimap = () => (
+  <div
+    style={{
+      position: 'absolute',
+      left: 16,
+      bottom: 51,
+      zIndex: 100,
+      width: 198,
+    }}
+  >
+    <MinimapRender
+      containerStyles={{
+        pointerEvents: 'auto',
+        position: 'relative',
+        top: 'unset',
+        right: 'unset',
+        bottom: 'unset',
+        left: 'unset',
       }}
-    >
-      <MinimapRender
-        service={minimapService}
-        containerStyles={{
-          pointerEvents: 'auto',
-          position: 'relative',
-          top: 'unset',
-          right: 'unset',
-          bottom: 'unset',
-          left: 'unset',
-        }}
-        inactiveStyle={{
-          opacity: 1,
-          scale: 1,
-          translateX: 0,
-          translateY: 0,
-        }}
-      />
-    </div>
-  );
-};
+      inactiveStyle={{
+        opacity: 1,
+        scale: 1,
+        translateX: 0,
+        translateY: 0,
+      }}
+    />
+  </div>
+);

--- a/apps/demo-fixed-layout-simple/src/hooks/use-editor-props.tsx
+++ b/apps/demo-fixed-layout-simple/src/hooks/use-editor-props.tsx
@@ -182,7 +182,6 @@ export function useEditorProps(
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
       ],
     }),

--- a/apps/demo-fixed-layout/src/components/node-adder/styles.tsx
+++ b/apps/demo-fixed-layout/src/components/node-adder/styles.tsx
@@ -26,7 +26,4 @@ export const Wrap = styled.div`
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  svg: {
-    transform: scale(0.7);
-  }
 `;

--- a/apps/demo-fixed-layout/src/components/tools/minimap.tsx
+++ b/apps/demo-fixed-layout/src/components/tools/minimap.tsx
@@ -3,20 +3,17 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/fixed-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
 import { MinimapContainer } from './styles';
 
 export const Minimap = ({ visible }: { visible?: boolean }) => {
-  const minimapService = useService(FlowMinimapService);
   if (!visible) {
     return <></>;
   }
   return (
     <MinimapContainer>
       <MinimapRender
-        service={minimapService}
         panelStyles={{}}
         containerStyles={{
           pointerEvents: 'auto',

--- a/apps/demo-fixed-layout/src/hooks/use-editor-props.ts
+++ b/apps/demo-fixed-layout/src/hooks/use-editor-props.ts
@@ -265,7 +265,6 @@ export function useEditorProps(
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         /**
          * Group plugin

--- a/apps/demo-free-layout-simple/src/components/minimap.tsx
+++ b/apps/demo-free-layout-simple/src/components/minimap.tsx
@@ -3,38 +3,33 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/free-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
-export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: 226,
-        bottom: 51,
-        zIndex: 100,
-        width: 198,
+export const Minimap = () => (
+  <div
+    style={{
+      position: 'absolute',
+      left: 226,
+      bottom: 51,
+      zIndex: 100,
+      width: 198,
+    }}
+  >
+    <MinimapRender
+      containerStyles={{
+        pointerEvents: 'auto',
+        position: 'relative',
+        top: 'unset',
+        right: 'unset',
+        bottom: 'unset',
+        left: 'unset',
       }}
-    >
-      <MinimapRender
-        service={minimapService}
-        containerStyles={{
-          pointerEvents: 'auto',
-          position: 'relative',
-          top: 'unset',
-          right: 'unset',
-          bottom: 'unset',
-          left: 'unset',
-        }}
-        inactiveStyle={{
-          opacity: 1,
-          scale: 1,
-          translateX: 0,
-          translateY: 0,
-        }}
-      />
-    </div>
-  );
-};
+      inactiveStyle={{
+        opacity: 1,
+        scale: 1,
+        translateX: 0,
+        translateY: 0,
+      }}
+    />
+  </div>
+);

--- a/apps/demo-free-layout-simple/src/hooks/use-editor-props.tsx
+++ b/apps/demo-free-layout-simple/src/hooks/use-editor-props.tsx
@@ -173,7 +173,6 @@ export const useEditorProps = () =>
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         /**
          * Snap plugin

--- a/apps/demo-free-layout/src/components/tools/minimap.tsx
+++ b/apps/demo-free-layout/src/components/tools/minimap.tsx
@@ -3,20 +3,17 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/free-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
 import { MinimapContainer } from './styles';
 
 export const Minimap = ({ visible }: { visible?: boolean }) => {
-  const minimapService = useService(FlowMinimapService);
   if (!visible) {
     return <></>;
   }
   return (
     <MinimapContainer>
       <MinimapRender
-        service={minimapService}
         panelStyles={{}}
         containerStyles={{
           pointerEvents: 'auto',

--- a/apps/demo-free-layout/src/hooks/use-editor-props.tsx
+++ b/apps/demo-free-layout/src/hooks/use-editor-props.tsx
@@ -318,7 +318,6 @@ export function useEditorProps(
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0.55)',
           },
-          inactiveDebounceTime: 1,
         }),
 
         /**

--- a/apps/demo-nextjs-antd/src/editor/hooks/use-editor-props.tsx
+++ b/apps/demo-nextjs-antd/src/editor/hooks/use-editor-props.tsx
@@ -154,7 +154,6 @@ export const useEditorProps = (initialData: WorkflowJSON, nodeRegistries: FlowNo
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         /**
          * Snap plugin

--- a/apps/demo-nextjs/src/editor/hooks/use-editor-props.tsx
+++ b/apps/demo-nextjs/src/editor/hooks/use-editor-props.tsx
@@ -123,7 +123,6 @@ export const useEditorProps = () =>
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         /**
          * Snap plugin

--- a/apps/demo-node-form/src/hooks/use-editor-props.tsx
+++ b/apps/demo-node-form/src/hooks/use-editor-props.tsx
@@ -151,7 +151,6 @@ export const useEditorProps = ({
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         /**
          * Snap plugin

--- a/apps/demo-react-16/src/components/minimap.tsx
+++ b/apps/demo-react-16/src/components/minimap.tsx
@@ -5,38 +5,33 @@
 
 import React from 'react';
 
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/free-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
-export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: 226,
-        bottom: 51,
-        zIndex: 100,
-        width: 198,
+export const Minimap = () => (
+  <div
+    style={{
+      position: 'absolute',
+      left: 226,
+      bottom: 51,
+      zIndex: 100,
+      width: 198,
+    }}
+  >
+    <MinimapRender
+      containerStyles={{
+        pointerEvents: 'auto',
+        position: 'relative',
+        top: 'unset',
+        right: 'unset',
+        bottom: 'unset',
+        left: 'unset',
       }}
-    >
-      <MinimapRender
-        service={minimapService}
-        containerStyles={{
-          pointerEvents: 'auto',
-          position: 'relative',
-          top: 'unset',
-          right: 'unset',
-          bottom: 'unset',
-          left: 'unset',
-        }}
-        inactiveStyle={{
-          opacity: 1,
-          scale: 1,
-          translateX: 0,
-          translateY: 0,
-        }}
-      />
-    </div>
-  );
-};
+      inactiveStyle={{
+        opacity: 1,
+        scale: 1,
+        translateX: 0,
+        translateY: 0,
+      }}
+    />
+  </div>
+);

--- a/apps/demo-react-16/src/hooks/use-editor-props.tsx
+++ b/apps/demo-react-16/src/hooks/use-editor-props.tsx
@@ -141,7 +141,6 @@ export const useEditorProps = () =>
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         /**
          * Snap plugin

--- a/apps/demo-vite/src/components/minimap.tsx
+++ b/apps/demo-vite/src/components/minimap.tsx
@@ -3,38 +3,33 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/free-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
-export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
-  return (
-    <div
-      style={{
-        position: 'absolute',
-        left: 226,
-        bottom: 51,
-        zIndex: 100,
-        width: 198,
+export const Minimap = () => (
+  <div
+    style={{
+      position: 'absolute',
+      left: 226,
+      bottom: 51,
+      zIndex: 100,
+      width: 198,
+    }}
+  >
+    <MinimapRender
+      containerStyles={{
+        pointerEvents: 'auto',
+        position: 'relative',
+        top: 'unset',
+        right: 'unset',
+        bottom: 'unset',
+        left: 'unset',
       }}
-    >
-      <MinimapRender
-        service={minimapService}
-        containerStyles={{
-          pointerEvents: 'auto',
-          position: 'relative',
-          top: 'unset',
-          right: 'unset',
-          bottom: 'unset',
-          left: 'unset',
-        }}
-        inactiveStyle={{
-          opacity: 1,
-          scale: 1,
-          translateX: 0,
-          translateY: 0,
-        }}
-      />
-    </div>
-  );
-};
+      inactiveStyle={{
+        opacity: 1,
+        scale: 1,
+        translateX: 0,
+        translateY: 0,
+      }}
+    />
+  </div>
+);

--- a/apps/demo-vite/src/hooks/use-editor-props.tsx
+++ b/apps/demo-vite/src/hooks/use-editor-props.tsx
@@ -151,7 +151,6 @@ export const useEditorProps = () =>
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         /**
          * Snap plugin

--- a/apps/docs/src/en/examples/free-layout/free-layout-simple.mdx
+++ b/apps/docs/src/en/examples/free-layout/free-layout-simple.mdx
@@ -355,11 +355,9 @@ export const Tools: React.FC = () => {
 };
 
 // src/components/minimap.tsx
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/free-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
 export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
   return (
     <div
       style={{
@@ -371,7 +369,6 @@ export const Minimap = () => {
       }}
     >
       <MinimapRender
-        service={minimapService}
         containerStyles={{
           pointerEvents: 'auto',
           position: 'relative',

--- a/apps/docs/src/en/examples/free-layout/free-layout-simple.mdx
+++ b/apps/docs/src/en/examples/free-layout/free-layout-simple.mdx
@@ -267,7 +267,6 @@ export const useEditorProps = () =>
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         // Auto-alignment plugin
         createFreeSnapPlugin({

--- a/apps/docs/src/en/guide/advanced/minimap.mdx
+++ b/apps/docs/src/en/guide/advanced/minimap.mdx
@@ -46,12 +46,9 @@ import { createMinimapPlugin } from '@flowgram.ai/minimap-plugin'
 ## Minimap Component
 
 ```tsx pure
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/editor'; // or free-layout-editor
-
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
 export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
   return (
     <div
       style={{
@@ -63,7 +60,6 @@ export const Minimap = () => {
       }}
     >
       <MinimapRender
-        service={minimapService}
         containerStyles={{
           pointerEvents: 'auto',
           position: 'relative',

--- a/apps/docs/src/en/guide/advanced/minimap.mdx
+++ b/apps/docs/src/en/guide/advanced/minimap.mdx
@@ -38,7 +38,6 @@ import { createMinimapPlugin } from '@flowgram.ai/minimap-plugin'
         nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
         overlayColor: 'rgba(255, 255, 255, 0)',
       },
-      inactiveDebounceTime: 1,
     }),
   ]
 }

--- a/apps/docs/src/zh/examples/free-layout/free-layout-simple.mdx
+++ b/apps/docs/src/zh/examples/free-layout/free-layout-simple.mdx
@@ -357,11 +357,9 @@ export const Tools: React.FC = () => {
 };
 
 // src/components/minimap.tsx
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/free-layout-editor';
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
 export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
   return (
     <div
       style={{
@@ -373,7 +371,6 @@ export const Minimap = () => {
       }}
     >
       <MinimapRender
-        service={minimapService}
         containerStyles={{
           pointerEvents: 'auto',
           position: 'relative',

--- a/apps/docs/src/zh/examples/free-layout/free-layout-simple.mdx
+++ b/apps/docs/src/zh/examples/free-layout/free-layout-simple.mdx
@@ -267,7 +267,6 @@ export const useEditorProps = () =>
             nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
             overlayColor: 'rgba(255, 255, 255, 0)',
           },
-          inactiveDebounceTime: 1,
         }),
         // 自动对齐插件
         createFreeSnapPlugin({

--- a/apps/docs/src/zh/guide/advanced/minimap.mdx
+++ b/apps/docs/src/zh/guide/advanced/minimap.mdx
@@ -46,12 +46,10 @@ import { createMinimapPlugin } from '@flowgram.ai/minimap-plugin'
 ## 缩略图组件
 
 ```tsx pure
-import { FlowMinimapService, MinimapRender } from '@flowgram.ai/minimap-plugin';
-import { useService } from '@flowgram.ai/editor'; // 或 free-layout-editor
+import { MinimapRender } from '@flowgram.ai/minimap-plugin';
 
 
 export const Minimap = () => {
-  const minimapService = useService(FlowMinimapService);
   return (
     <div
       style={{
@@ -63,7 +61,6 @@ export const Minimap = () => {
       }}
     >
       <MinimapRender
-        service={minimapService}
         containerStyles={{
           pointerEvents: 'auto',
           position: 'relative',

--- a/apps/docs/src/zh/guide/advanced/minimap.mdx
+++ b/apps/docs/src/zh/guide/advanced/minimap.mdx
@@ -38,7 +38,6 @@ import { createMinimapPlugin } from '@flowgram.ai/minimap-plugin'
         nodeBorderColor: 'rgba(6, 7, 9, 0.10)',
         overlayColor: 'rgba(255, 255, 255, 0)',
       },
-      inactiveDebounceTime: 1,
     }),
   ]
 }

--- a/packages/plugins/minimap-plugin/src/component.tsx
+++ b/packages/plugins/minimap-plugin/src/component.tsx
@@ -38,8 +38,11 @@ export const MinimapRender: React.FC<MinimapProps> = (props) => {
     const disposer = service.onActive((activate: boolean) => {
       setActivated(activate);
     });
+    service.setVisible(true)
+    service.render();
     return () => {
       disposer.dispose();
+      service.setVisible(false)
     };
   }, []);
 

--- a/packages/plugins/minimap-plugin/src/component.tsx
+++ b/packages/plugins/minimap-plugin/src/component.tsx
@@ -5,28 +5,27 @@
 
 import React, { CSSProperties, useEffect, useRef, useState } from 'react';
 
+import { usePlaygroundContainer } from '@flowgram.ai/core';
+
 import { MinimapInactiveStyle } from './type';
 import { FlowMinimapService } from './service';
 import { MinimapDefaultInactiveStyle } from './constant';
 
 interface MinimapProps {
-  service: FlowMinimapService;
+  service?: FlowMinimapService;
   panelStyles?: CSSProperties;
   containerStyles?: CSSProperties;
   inactiveStyle?: Partial<MinimapInactiveStyle>;
 }
 
 export const MinimapRender: React.FC<MinimapProps> = (props) => {
-  const {
-    service,
-    panelStyles = {},
-    containerStyles = {},
-    inactiveStyle: customInactiveStyle = {},
-  } = props;
+  const { panelStyles = {}, containerStyles = {}, inactiveStyle: customInactiveStyle = {} } = props;
   const inactiveStyle = {
     ...MinimapDefaultInactiveStyle,
     ...customInactiveStyle,
   };
+  const playgroundContainer = usePlaygroundContainer();
+  const service = props.service || playgroundContainer?.get(FlowMinimapService);
   const panelRef = useRef<HTMLDivElement>(null);
   const [activated, setActivated] = useState<boolean>(false);
 
@@ -38,13 +37,13 @@ export const MinimapRender: React.FC<MinimapProps> = (props) => {
     const disposer = service.onActive((activate: boolean) => {
       setActivated(activate);
     });
-    service.setVisible(true)
+    service.setVisible(true);
     service.render();
     return () => {
       disposer.dispose();
-      service.setVisible(false)
+      service.setVisible(false);
     };
-  }, []);
+  }, [service]);
 
   // 计算缩放比例和透明度
   const scale: number = activated ? 1 : inactiveStyle.scale;

--- a/packages/plugins/minimap-plugin/src/constant.ts
+++ b/packages/plugins/minimap-plugin/src/constant.ts
@@ -36,6 +36,6 @@ export const MinimapDefaultOptions: MinimapServiceOptions = {
   enableActiveDebounce: false,
   enableInactiveDebounce: true,
   enableDisplayAllNodes: false,
-  activeDebounceTime: 0,
-  inactiveDebounceTime: 5,
+  activeThrottleTime: 0,
+  inactiveThrottleTime: 24,
 };

--- a/packages/plugins/minimap-plugin/src/constant.ts
+++ b/packages/plugins/minimap-plugin/src/constant.ts
@@ -33,8 +33,6 @@ export const MinimapDefaultInactiveStyle: MinimapInactiveStyle = {
 export const MinimapDefaultOptions: MinimapServiceOptions = {
   canvasStyle: MinimapDefaultCanvasStyle,
   canvasClassName: 'gedit-minimap-canvas',
-  enableActiveDebounce: false,
-  enableInactiveDebounce: true,
   enableDisplayAllNodes: false,
   activeThrottleTime: 0,
   inactiveThrottleTime: 24,

--- a/packages/plugins/minimap-plugin/src/layer.tsx
+++ b/packages/plugins/minimap-plugin/src/layer.tsx
@@ -6,9 +6,18 @@
 import React from 'react';
 
 import { inject, injectable } from 'inversify';
-import { Layer, observeEntityDatas, observeEntity, PlaygroundConfigEntity, TransformData } from '@flowgram.ai/core';
-import { FlowNodeEntity } from '@flowgram.ai/document'
 import { domUtils } from '@flowgram.ai/utils';
+import {
+  FlowNodeEntity,
+  FlowNodeTransformData,
+  FlowDocumentTransformerEntity,
+} from '@flowgram.ai/document';
+import {
+  Layer,
+  observeEntityDatas,
+  observeEntity,
+  PlaygroundConfigEntity,
+} from '@flowgram.ai/core';
 
 import { MinimapLayerOptions } from './type';
 import { FlowMinimapService } from './service';
@@ -19,8 +28,14 @@ export class FlowMinimapLayer extends Layer<MinimapLayerOptions> {
   public static type = 'FlowMinimapLayer';
 
   @inject(FlowMinimapService) private readonly service: FlowMinimapService;
-  @observeEntityDatas(FlowNodeEntity, TransformData) transformDatas: TransformData[];
+
+  @observeEntityDatas(FlowNodeEntity, FlowNodeTransformData)
+  transformDatas: FlowNodeTransformData[];
+
   @observeEntity(PlaygroundConfigEntity) configEntity: PlaygroundConfigEntity;
+
+  @observeEntity(FlowDocumentTransformerEntity)
+  readonly documentTransformer: FlowDocumentTransformerEntity;
 
   public readonly node: HTMLElement;
 
@@ -33,7 +48,9 @@ export class FlowMinimapLayer extends Layer<MinimapLayerOptions> {
   }
 
   public render(): JSX.Element {
-    this.service.render()
+    if (this.documentTransformer.loading) return <></>;
+    this.documentTransformer.refresh();
+    this.service.render();
     if (this.options.disableLayer) {
       return <></>;
     }

--- a/packages/plugins/minimap-plugin/src/layer.tsx
+++ b/packages/plugins/minimap-plugin/src/layer.tsx
@@ -6,7 +6,8 @@
 import React from 'react';
 
 import { inject, injectable } from 'inversify';
-import { Layer } from '@flowgram.ai/core';
+import { Layer, observeEntityDatas, observeEntity, PlaygroundConfigEntity, TransformData } from '@flowgram.ai/core';
+import { FlowNodeEntity } from '@flowgram.ai/document'
 import { domUtils } from '@flowgram.ai/utils';
 
 import { MinimapLayerOptions } from './type';
@@ -18,6 +19,8 @@ export class FlowMinimapLayer extends Layer<MinimapLayerOptions> {
   public static type = 'FlowMinimapLayer';
 
   @inject(FlowMinimapService) private readonly service: FlowMinimapService;
+  @observeEntityDatas(FlowNodeEntity, TransformData) transformDatas: TransformData[];
+  @observeEntity(PlaygroundConfigEntity) configEntity: PlaygroundConfigEntity;
 
   public readonly node: HTMLElement;
 
@@ -30,6 +33,7 @@ export class FlowMinimapLayer extends Layer<MinimapLayerOptions> {
   }
 
   public render(): JSX.Element {
+    this.service.render()
     if (this.options.disableLayer) {
       return <></>;
     }

--- a/packages/plugins/minimap-plugin/src/service.ts
+++ b/packages/plugins/minimap-plugin/src/service.ts
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { debounce } from 'lodash-es';
+import { throttle } from 'lodash-es';
 import { inject, injectable } from 'inversify';
 import { Disposable, DisposableCollection, IPoint, Rectangle } from '@flowgram.ai/utils';
 import { FlowNodeEntity, FlowNodeTransformData } from '@flowgram.ai/document';
 import { FlowNodeBaseType } from '@flowgram.ai/document';
 import { FlowDocument } from '@flowgram.ai/document';
-import { EntityManager, MouseTouchEvent, PlaygroundConfigEntity } from '@flowgram.ai/core';
+import { MouseTouchEvent, PlaygroundConfigEntity } from '@flowgram.ai/core';
 
 import type { MinimapRenderContext, MinimapServiceOptions, MinimapCanvasStyle } from './type';
 import { MinimapDraw } from './draw';
@@ -18,8 +18,6 @@ import { MinimapDefaultCanvasStyle, MinimapDefaultOptions } from './constant';
 @injectable()
 export class FlowMinimapService {
   @inject(FlowDocument) private readonly document: FlowDocument;
-
-  @inject(EntityManager) private readonly entityManager: EntityManager;
 
   @inject(PlaygroundConfigEntity)
   private readonly playgroundConfig: PlaygroundConfigEntity;
@@ -37,6 +35,7 @@ export class FlowMinimapService {
   private toDispose: DisposableCollection;
 
   private initialized;
+  private visible: boolean = false;
 
   private isDragging;
 
@@ -58,12 +57,8 @@ export class FlowMinimapService {
   public init(options?: Partial<MinimapServiceOptions>) {
     this.options = MinimapDefaultOptions;
     Object.assign(this.options, options);
-    this.setDebounce({
-      enableDebounce: this.options.enableInactiveDebounce,
-      debounceTime: this.options.inactiveDebounceTime,
-    });
+    this.setThrottle(this.options.inactiveThrottleTime);
     this.initStyle();
-    this.mountListener();
   }
 
   public dispose(): void {
@@ -71,6 +66,9 @@ export class FlowMinimapService {
     this.initialized = false;
     this.activated = false;
     this.removeEventListeners();
+  }
+  setVisible(visible: boolean) {
+    this.visible = visible
   }
 
   public setActivate(activate: boolean): void {
@@ -83,16 +81,10 @@ export class FlowMinimapService {
     }
     this.activated = activate;
     if (activate) {
-      this.setDebounce({
-        enableDebounce: this.options.enableActiveDebounce,
-        debounceTime: this.options.activeDebounceTime,
-      });
+      this.setThrottle(this.options.activeThrottleTime);
       this.addEventListeners();
     } else {
-      this.setDebounce({
-        enableDebounce: this.options.enableInactiveDebounce,
-        debounceTime: this.options.inactiveDebounceTime,
-      });
+      this.setThrottle(this.options.inactiveThrottleTime);
       this.removeEventListeners();
     }
     this.render();
@@ -125,22 +117,17 @@ export class FlowMinimapService {
       : 'unset';
   }
 
-  private setDebounce(params: { enableDebounce: boolean; debounceTime: number }) {
-    const { enableDebounce, debounceTime } = params;
-    if (enableDebounce) {
-      this.render = debounce(this._render, debounceTime);
-    } else {
-      this.render = this._render;
-    }
+  private setThrottle(throttleTime: number) {
+    this.render = throttle(this._render, throttleTime);
   }
 
   /**
    * 触发渲染
    */
-  private render: () => void = this._render;
+  public render: () => void = this._render;
 
   private _render(): void {
-    if (!this.initialized) {
+    if (!this.initialized || !this.visible) {
       return;
     }
     const renderContext = this.createRenderContext();
@@ -286,11 +273,6 @@ export class FlowMinimapService {
   private viewRect(): Rectangle {
     const { width, height, scrollX, scrollY, zoom } = this.playgroundConfig.config;
     return new Rectangle(scrollX / zoom, scrollY / zoom, width / zoom, height / zoom);
-  }
-
-  private mountListener(): void {
-    const entityManagerDisposer = this.entityManager.onEntityChange(() => this.render());
-    this.toDispose.push(entityManagerDisposer);
   }
 
   /** 计算画布坐标系下的矩形 */

--- a/packages/plugins/minimap-plugin/src/type.ts
+++ b/packages/plugins/minimap-plugin/src/type.ts
@@ -38,8 +38,8 @@ export interface MinimapServiceOptions {
   enableInactiveDebounce: boolean;
   enableActiveDebounce: boolean;
   enableDisplayAllNodes: boolean;
-  activeDebounceTime: number;
-  inactiveDebounceTime: number;
+  activeThrottleTime: number;
+  inactiveThrottleTime: number;
 }
 
 export interface MinimapLayerOptions {

--- a/packages/plugins/minimap-plugin/src/type.ts
+++ b/packages/plugins/minimap-plugin/src/type.ts
@@ -35,8 +35,6 @@ export interface MinimapInactiveStyle {
 export interface MinimapServiceOptions {
   canvasStyle: Partial<MinimapCanvasStyle>;
   canvasClassName: string;
-  enableInactiveDebounce: boolean;
-  enableActiveDebounce: boolean;
   enableDisplayAllNodes: boolean;
   activeThrottleTime: number;
   inactiveThrottleTime: number;


### PR DESCRIPTION
1. throttle 替代 debounce，去掉 enableInactiveDebounce 和 enableActiveDebounce， inactiveDebounce -> inactiveThrottle, activeDebounce -> activeThrottle
2. 不要使用 entityManager.onChange 改成用 observeEntityDatas(FlowNodeEntity, TransformData)
3. 添加 setVisible，保证如果 缩略图不渲染不用计算 canvas
4. 默认值 inactiveThrottle 设置为 24 帧，眼睛不会感觉抖动