### PR TITLE
fix: coze-editor line highlight transparent

### DIFF
--- a/packages/materials/form-materials/src/components/code-editor/theme/dark.ts
+++ b/packages/materials/form-materials/src/components/code-editor/theme/dark.ts
@@ -47,7 +47,7 @@ export const darkTheme: Extension = createTheme({
     gutterForeground: colors.foreground,
     gutterBorderColor: 'transparent',
     gutterBorderWidth: 0,
-    lineHighlight: '#21262D',
+    lineHighlight: 'transparent',
     bracketColors: ['#FBBF24', '#A78BFA', '#7DD3FC'],
     tooltip: {
       backgroundColor: '#21262D',

--- a/packages/materials/form-materials/src/components/code-editor/theme/light.ts
+++ b/packages/materials/form-materials/src/components/code-editor/theme/light.ts
@@ -42,7 +42,7 @@ export const lightTheme: Extension = createTheme({
     gutterForeground: colors.foreground,
     gutterBorderColor: 'transparent',
     gutterBorderWidth: 0,
-    lineHighlight: '#efefef78',
+    lineHighlight: 'transparent',
     bracketColors: ['#F59E0B', '#8B5CF6', '#06B6D4'],
     tooltip: {
       backgroundColor: colors.dropdownBackground,

--- a/packages/materials/form-materials/src/components/code-editor/theme/light.ts
+++ b/packages/materials/form-materials/src/components/code-editor/theme/light.ts
@@ -42,7 +42,7 @@ export const lightTheme: Extension = createTheme({
     gutterForeground: colors.foreground,
     gutterBorderColor: 'transparent',
     gutterBorderWidth: 0,
-    lineHighlight: colors.background,
+    lineHighlight: '#efefef78',
     bracketColors: ['#F59E0B', '#8B5CF6', '#06B6D4'],
     tooltip: {
       backgroundColor: colors.dropdownBackground,


### PR DESCRIPTION

Fixes: https://github.com/bytedance/flowgram.ai/issues/872