### PR TITLE
fix(demo-free-layout): correct expand shortcut

### DIFF
--- a/apps/demo-free-layout/src/shortcuts/expand/index.ts
+++ b/apps/demo-free-layout/src/shortcuts/expand/index.ts
@@ -18,7 +18,7 @@ export class ExpandShortcut implements ShortcutsHandler {
     label: 'Expand',
   };
 
-  public shortcuts = ['meta alt closebracket', 'ctrl alt openbracket'];
+  public shortcuts = ['meta alt closebracket', 'ctrl alt closebracket'];
 
   private selectService: WorkflowSelectService;
 


### PR DESCRIPTION
## Summary

Fixes the Windows/Linux expand shortcut in the free layout demo.

The expand command was using `ctrl alt openbracket`, which matches the collapse shortcut. This updates it to `ctrl alt closebracket`, matching the existing macOS `meta alt closebracket` mapping.

Fixes #1132.

## Validation

- `node common/scripts/install-run-rush.js install`
- `node common/scripts/install-run-rush.js build --to @flowgram.ai/demo-free-layout`
- `node common/scripts/install-run-rush.js ts-check --to @flowgram.ai/demo-free-layout`
- `node common/scripts/install-run-rush.js lint --to @flowgram.ai/demo-free-layout`
- `git diff --check`
