### PR TITLE
fix(form): correct operator precedence in FieldArray default value check

### DIFF
--- a/packages/node-engine/form/src/react/field-array.tsx
+++ b/packages/node-engine/form/src/react/field-array.tsx
@@ -67,7 +67,7 @@ export function FieldArray<TValue extends FieldValue>({
     }
     fieldModel.renderCount = fieldModel.renderCount + 1;
 
-    if (!formModel.getValueIn(name) !== undefined && defaultValue !== undefined) {
+    if (formModel.getValueIn(name) === undefined && defaultValue !== undefined) {
       formModel.setInitValueIn(name, defaultValue);
       refresh();
     }


### PR DESCRIPTION
## Summary

Fix an operator precedence bug in FieldArray component where the condition always evaluates to true. The expression always overwrites existing values with defaults.

## Root Cause

Before: always true due to operator precedence
After: correctly checks if value is undefined

## Test plan

- Verify FieldArray defaultValue only sets when no value exists
- Verify existing values are preserved on re-render
- Run rush test