### PR TITLE
fix(minimap): use explicit return false in filter callbacks

### DIFF
--- a/packages/plugins/minimap-plugin/src/service.ts
+++ b/packages/plugins/minimap-plugin/src/service.ts
@@ -257,14 +257,14 @@ export class FlowMinimapService {
       // 去除不可见节点
       if (node.hidden) return false;
       // 去除根节点
-      if (node.flowNodeType === FlowNodeBaseType.ROOT) return;
+      if (node.flowNodeType === FlowNodeBaseType.ROOT) return false;
       // 去除非一级节点
       if (
         !this.options.enableDisplayAllNodes &&
         node.parent &&
         node.parent.flowNodeType !== FlowNodeBaseType.ROOT
       )
-        return;
+        return false;
       return true;
     });
   }


### PR DESCRIPTION
Fix return; statements in Array.filter() callbacks in minimap transformVisibles getter. Changed to explicit return false for correct semantics.

## Changes
- Line 260: return; -> return false
- Line 267: return; -> return false

## Test plan
- Verify minimap correctly filters root and non-first-level nodes
- Run rush test