### PR TITLE
fix(cli): remove duplicate argument in npm view commands

### DIFF
--- a/apps/cli/src/create-app/index.ts
+++ b/apps/cli/src/create-app/index.ts
@@ -51,7 +51,7 @@ function downloadFile(url: string, dest: string): Promise<void> {
 
 export const createApp = async (projectName?: string) => {
   console.log(chalk.green('Welcome to @flowgram.ai/create-app CLI!'));
-  const latest = execSync('npm view @flowgram.ai/demo-fixed-layout version --tag=latest latest')
+  const latest = execSync('npm view @flowgram.ai/demo-fixed-layout version')
     .toString()
     .trim();
 
@@ -131,7 +131,7 @@ export const createApp = async (projectName?: string) => {
     const pkgJsonPath = path.join(targetDir, folderName, 'package.json');
     const data = fs.readFileSync(pkgJsonPath, 'utf-8');
 
-    const packageLatestVersion = execSync('npm view @flowgram.ai/core version --tag=latest latest')
+    const packageLatestVersion = execSync('npm view @flowgram.ai/core version')
       .toString()
       .trim();
 


### PR DESCRIPTION
## Summary

Fix malformed npm view commands in the CLI create-app tool. The trailing `latest` argument was being interpreted as a second field name to query, not as a tag flag.

## Root Cause

Two npm view commands in `apps/cli/src/create-app/index.ts` have a duplicate `latest` argument:

```bash
# Before (bug): queries both 'version' AND 'latest' fields
npm view @flowgram.ai/demo-fixed-layout version --tag=latest latest
npm view @flowgram.ai/core version --tag=latest latest

# After (fix): correctly queries only 'version' field  
npm view @flowgram.ai/demo-fixed-layout version
npm view @flowgram.ai/core version
```

The `npm view <pkg> <field1> <field2>` syntax queries multiple fields. The trailing `latest` was being treated as a field name, causing the output to include both the version and an undefined `latest` field, which could corrupt the version string.

Note: `npm view` already defaults to the `latest` tag, so `--tag=latest` is unnecessary.

## Test plan

- [x] Verify `npm view @flowgram.ai/demo-fixed-layout version` returns a clean version string
- [x] Verify `npm view @flowgram.ai/core version` returns a clean version string