### PR TITLE
fix(runtime): Support object loop entries

### DIFF
--- a/packages/runtime/js-core/src/domain/__tests__/schemas/loop.test.ts
+++ b/packages/runtime/js-core/src/domain/__tests__/schemas/loop.test.ts
@@ -4,7 +4,12 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { IContainer, IEngine, WorkflowStatus } from '@flowgram.ai/runtime-interface';
+import {
+  IContainer,
+  IEngine,
+  WorkflowSchema,
+  WorkflowStatus,
+} from '@flowgram.ai/runtime-interface';
 
 import { snapshotsToVOData } from '../utils';
 import { WorkflowRuntimeContainer } from '../../container';
@@ -281,5 +286,175 @@ describe('WorkflowRuntime loop schema', () => {
     expect(report.reports.llm_0.snapshots.length).toBe(8);
     expect(report.reports.block_start_0.snapshots.length).toBe(8);
     expect(report.reports.block_end_0.snapshots.length).toBe(8);
+  });
+  it('should execute a workflow over object entries', async () => {
+    const engine = container.get<IEngine>(IEngine);
+    const schema: WorkflowSchema = {
+      nodes: [
+        {
+          id: 'start_0',
+          type: 'start',
+          meta: {
+            position: {
+              x: 180,
+              y: 230,
+            },
+          },
+          data: {
+            title: 'Start',
+            outputs: {
+              type: 'object',
+              properties: {
+                taskMap: {
+                  type: 'object',
+                },
+              },
+              required: ['taskMap'],
+            },
+          },
+        },
+        {
+          id: 'end_0',
+          type: 'end',
+          meta: {
+            position: {
+              x: 880,
+              y: 230,
+            },
+          },
+          data: {
+            title: 'End',
+            inputs: {
+              type: 'object',
+              properties: {
+                items: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+                keys: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+                indexes: {
+                  type: 'array',
+                  items: {
+                    type: 'number',
+                  },
+                },
+              },
+            },
+            inputsValues: {
+              items: {
+                type: 'ref',
+                content: ['loop_0', 'items'],
+              },
+              keys: {
+                type: 'ref',
+                content: ['loop_0', 'keys'],
+              },
+              indexes: {
+                type: 'ref',
+                content: ['loop_0', 'indexes'],
+              },
+            },
+          },
+        },
+        {
+          id: 'loop_0',
+          type: 'loop',
+          meta: {
+            position: {
+              x: 520,
+              y: 230,
+            },
+          },
+          data: {
+            title: 'Loop_1',
+            loopFor: {
+              type: 'ref',
+              content: ['start_0', 'taskMap'],
+            },
+            loopOutputs: {
+              items: {
+                type: 'ref',
+                content: ['loop_0_locals', 'item'],
+              },
+              keys: {
+                type: 'ref',
+                content: ['loop_0_locals', 'key'],
+              },
+              indexes: {
+                type: 'ref',
+                content: ['loop_0_locals', 'index'],
+              },
+            },
+          },
+          blocks: [
+            {
+              id: 'block_start_0',
+              type: 'block-start',
+              meta: {
+                position: {
+                  x: 32,
+                  y: 149.5,
+                },
+              },
+              data: {},
+            },
+            {
+              id: 'block_end_0',
+              type: 'block-end',
+              meta: {
+                position: {
+                  x: 320,
+                  y: 149.5,
+                },
+              },
+              data: {},
+            },
+          ],
+          edges: [
+            {
+              sourceNodeID: 'block_start_0',
+              targetNodeID: 'block_end_0',
+            },
+          ],
+        },
+      ],
+      edges: [
+        {
+          sourceNodeID: 'start_0',
+          targetNodeID: 'loop_0',
+        },
+        {
+          sourceNodeID: 'loop_0',
+          targetNodeID: 'end_0',
+        },
+      ],
+    };
+    const { context, processing } = engine.invoke({
+      schema,
+      inputs: {
+        taskMap: {
+          first: 'TASK - A',
+          second: 'TASK - B',
+          third: 'TASK - C',
+        },
+      },
+    });
+
+    expect(context.statusCenter.workflow.status).toBe(WorkflowStatus.Processing);
+    const result = await processing;
+
+    expect(context.statusCenter.workflow.status).toBe(WorkflowStatus.Succeeded);
+    expect(result).toStrictEqual({
+      items: ['TASK - A', 'TASK - B', 'TASK - C'],
+      keys: ['first', 'second', 'third'],
+      indexes: [0, 1, 2],
+    });
   });
 });

--- a/packages/runtime/js-core/src/nodes/loop/index.ts
+++ b/packages/runtime/js-core/src/nodes/loop/index.ts
@@ -21,11 +21,20 @@ import {
 import { WorkflowRuntimeType } from '@infra/index';
 
 type LoopArray = Array<any>;
+type LoopObject = Record<string, any>;
+type LoopIterable = LoopArray | LoopObject;
+type LoopEntry = {
+  key?: string;
+  index: number;
+  value: any;
+  type: WorkflowVariableType;
+  itemsType?: WorkflowVariableType;
+};
 type LoopBlockVariables = Record<string, IVariableParseResult>;
 type LoopOutputs = Record<string, any>;
 
 export interface LoopExecutorInputs {
-  loopFor: LoopArray;
+  loopFor: LoopIterable;
 }
 
 export class LoopExecutor implements INodeExecutor {
@@ -35,7 +44,7 @@ export class LoopExecutor implements INodeExecutor {
     const loopNodeID = context.node.id;
 
     const engine = context.container.get<IEngine>(IEngine);
-    const { value: loopArray, itemsType } = this.getLoopArrayVariable(context);
+    const loopEntries = this.getLoopEntries(context);
     const subNodes = context.node.children;
     const blockStartNode = subNodes.find((node) => node.type === FlowGramNode.BlockStart);
 
@@ -46,20 +55,29 @@ export class LoopExecutor implements INodeExecutor {
     const blockOutputs: LoopOutputs[] = [];
 
     // not use Array method to make error stack more concise, and better performance
-    for (let index = 0; index < loopArray.length; index++) {
-      const loopItem = loopArray[index];
+    for (let index = 0; index < loopEntries.length; index++) {
+      const loopEntry = loopEntries[index];
       const subContext = context.runtime.sub();
       subContext.variableStore.setVariable({
         nodeID: `${loopNodeID}_locals`,
         key: 'item',
-        type: itemsType,
-        value: loopItem,
+        type: loopEntry.type,
+        itemsType: loopEntry.itemsType,
+        value: loopEntry.value,
       });
+      if (!isNil(loopEntry.key)) {
+        subContext.variableStore.setVariable({
+          nodeID: `${loopNodeID}_locals`,
+          key: 'key',
+          type: WorkflowVariableType.String,
+          value: loopEntry.key,
+        });
+      }
       subContext.variableStore.setVariable({
         nodeID: `${loopNodeID}_locals`,
         key: 'index',
         type: WorkflowVariableType.Number,
-        value: index,
+        value: loopEntry.index,
       });
       try {
         await engine.executeNode({
@@ -87,34 +105,65 @@ export class LoopExecutor implements INodeExecutor {
     };
   }
 
-  private getLoopArrayVariable(
-    executionContext: ExecutionContext
-  ): IVariableParseResult<LoopArray> & {
-    itemsType: WorkflowVariableType;
-  } {
+  private getLoopEntries(executionContext: ExecutionContext): LoopEntry[] {
     const loopNodeData = executionContext.node.data as LoopNodeSchema['data'];
-    const LoopArrayVariable = executionContext.runtime.state.parseRef<LoopArray>(
+    const loopVariable = executionContext.runtime.state.parseRef<LoopIterable>(
       loopNodeData.loopFor
     );
-    this.checkLoopArray(LoopArrayVariable);
-    return LoopArrayVariable as IVariableParseResult<LoopArray> & {
-      itemsType: WorkflowVariableType;
-    };
+    this.checkLoopVariable(loopVariable);
+
+    if (Array.isArray(loopVariable.value)) {
+      return loopVariable.value.map((value, index) => ({
+        index,
+        value,
+        type: loopVariable.itemsType!,
+      }));
+    }
+
+    return Object.entries(loopVariable.value).map(([key, value], index) => ({
+      key,
+      index,
+      value,
+      ...this.getLoopItemType(value),
+    }));
   }
 
-  private checkLoopArray(LoopArrayVariable: IVariableParseResult<LoopArray> | null): void {
-    const loopArray = LoopArrayVariable?.value;
-    if (!loopArray || isNil(loopArray) || !Array.isArray(loopArray)) {
+  private checkLoopVariable(
+    LoopVariable: IVariableParseResult<LoopIterable> | null
+  ): asserts LoopVariable is IVariableParseResult<LoopIterable> {
+    const loopValue = LoopVariable?.value;
+    if (!loopValue || isNil(loopValue)) {
       throw new Error('Loop "loopFor" is required');
     }
-    const loopArrayType = LoopArrayVariable.type;
-    if (loopArrayType !== WorkflowVariableType.Array) {
-      throw new Error('Loop "loopFor" must be an array');
+    const loopType = LoopVariable.type;
+    if (loopType === WorkflowVariableType.Array) {
+      if (!Array.isArray(loopValue)) {
+        throw new Error('Loop "loopFor" must be an array or object');
+      }
+      const loopArrayItemType = LoopVariable.itemsType;
+      if (isNil(loopArrayItemType)) {
+        throw new Error('Loop "loopFor.items" must be array items');
+      }
+      return;
     }
-    const loopArrayItemType = LoopArrayVariable.itemsType;
-    if (isNil(loopArrayItemType)) {
-      throw new Error('Loop "loopFor.items" must be array items');
+    if (loopType !== WorkflowVariableType.Object || Array.isArray(loopValue)) {
+      throw new Error('Loop "loopFor" must be an array or object');
     }
+  }
+
+  private getLoopItemType(value: unknown): {
+    type: WorkflowVariableType;
+    itemsType?: WorkflowVariableType;
+  } {
+    const type = WorkflowRuntimeType.getWorkflowType(value);
+    if (!type) {
+      throw new Error('Loop "loopFor" contains unsupported object item');
+    }
+    if (type === WorkflowVariableType.Array && Array.isArray(value)) {
+      const itemsType = WorkflowRuntimeType.getWorkflowType(value[0]);
+      return isNil(itemsType) ? { type } : { type, itemsType };
+    }
+    return { type };
   }
 
   private getBlockOutput(


### PR DESCRIPTION
## Summary

- allow the runtime loop executor to iterate object entries in addition to arrays
- expose the current object entry key as `loop_0_locals.key` while keeping `item` as the entry value and `index` as the numeric iteration index
- add a runtime regression test covering object entry iteration

Closes #1089

## Validation

- `rush build --to @flowgram.ai/runtime-js`
- `cd packages/runtime/js-core && ./node_modules/.bin/vitest run src/domain/__tests__/schemas/loop.test.ts`
- `cd packages/runtime/js-core && ./node_modules/.bin/eslint src/nodes/loop/index.ts src/domain/__tests__/schemas/loop.test.ts`
- `cd packages/runtime/js-core && ./node_modules/.bin/tsc --noEmit`