### PR TITLE
fix(demo-free-layout): reset panel lock after select

### DIFF
--- a/apps/demo-free-layout/src/hooks/use-port-click.ts
+++ b/apps/demo-free-layout/src/hooks/use-port-click.ts
@@ -48,6 +48,7 @@ export const usePortClick = () => {
           ...params,
           enableMultiAdd: false,
           onSelect: async (panelParams?: NodePanelResult) => {
+            setActive(false);
             resolve(panelParams);
           },
           onClose: () => {


### PR DESCRIPTION
## Summary
Fixes the free layout demo issue where the node selection panel cannot be reopened from a port click after the first successful selection.

The panel lock state (`active`) was only reset on close, not on select. This update resets the lock in the select path as well, so subsequent port clicks can continue to open the panel as expected.

Fixes #1106.

## Validation
- `node common/scripts/install-run-rush.js update`
- `node common/scripts/install-run-rush.js build`
- `node common/scripts/install-run-rush.js lint`
- `cd apps/demo-free-layout && npm test`
- `node common/scripts/install-run-rush.js build --to @flowgram.ai/demo-free-layout`
- `node common/scripts/install-run-rush.js ts-check --to @flowgram.ai/demo-free-layout`
- `node common/scripts/install-run-rush.js lint --to @flowgram.ai/demo-free-layout`
- `git diff --check`