### PR TITLE
fix(free-layout-core): recompute line path when version unchanged but path is empty

### DIFF
--- a/packages/canvas-engine/free-layout-core/__tests__/workflow-line-render-data.test.ts
+++ b/packages/canvas-engine/free-layout-core/__tests__/workflow-line-render-data.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+import { interfaces } from 'inversify';
+import { FlowDocumentContainerModule } from '@flowgram.ai/document';
+import { PlaygroundMockTools } from '@flowgram.ai/core';
+
+import {
+  WorkflowDocument,
+  WorkflowDocumentContainerModule,
+  WorkflowLinesManager,
+  WorkflowLineRenderData,
+} from '../src';
+import { WorkflowSimpleLineContribution } from './simple-line';
+
+/**
+ * Build a container whose line contribution is NOT registered yet, so that a line can
+ * be created before its contribution becomes available. This mirrors the real timing
+ * issue where a line entity is created (e.g. during fromJSON) before free-lines-plugin
+ * onReady registers the bezier/fold/straight contributions.
+ */
+function createContainerWithoutLineContribution(): {
+  container: interfaces.Container;
+  document: WorkflowDocument;
+  linesManager: WorkflowLinesManager;
+} {
+  const container = PlaygroundMockTools.createContainer([
+    FlowDocumentContainerModule,
+    WorkflowDocumentContainerModule,
+  ]);
+  const document = container.get(WorkflowDocument);
+  const linesManager = container.get(WorkflowLinesManager);
+  linesManager.init(document);
+  // Select SimpleLine as the active line type, but intentionally do NOT register its
+  // contribution yet.
+  linesManager.switchLineType(WorkflowSimpleLineContribution.type);
+  return { container, document, linesManager };
+}
+
+describe('workflow-line-render-data', () => {
+  it('recomputes an empty path when the contribution registers after the version is set', () => {
+    const { document, linesManager } = createContainerWithoutLineContribution();
+    document.createWorkflowNode({
+      id: 'start_0',
+      type: 'start',
+      meta: { position: { x: 0, y: 0 } },
+    });
+    document.createWorkflowNode({
+      id: 'end_0',
+      type: 'end',
+      meta: { position: { x: 800, y: 0 } },
+    });
+
+    const line = linesManager.createLine({ from: 'start_0', to: 'end_0' })!;
+    const renderData = line.getData(WorkflowLineRenderData);
+
+    // First update runs while no contribution is available: the version is set to the
+    // real coordinates, but currentLine is undefined so the path stays empty.
+    renderData.update();
+    const versionAfterFirstUpdate = renderData.renderVersion;
+    expect(versionAfterFirstUpdate).not.toBe('');
+    expect(renderData.path).toBe('');
+
+    // The contribution becomes available later (free-lines-plugin onReady).
+    linesManager.registerContribution(WorkflowSimpleLineContribution);
+
+    // The position has not changed, so the version stays identical. Without the fix the
+    // version guard would permanently skip recomputation and the path would remain empty;
+    // with the fix the still-empty path is recomputed once the contribution exists.
+    renderData.update();
+    expect(renderData.renderVersion).toBe(versionAfterFirstUpdate);
+    expect(renderData.path).not.toBe('');
+    expect(renderData.path).toMatch(/^M .+ L .+$/);
+  });
+
+  it('keeps skipping recomputation once a non-empty path has been computed', () => {
+    const { document, linesManager } = createContainerWithoutLineContribution();
+    linesManager.registerContribution(WorkflowSimpleLineContribution);
+    document.createWorkflowNode({
+      id: 'start_0',
+      type: 'start',
+      meta: { position: { x: 0, y: 0 } },
+    });
+    document.createWorkflowNode({
+      id: 'end_0',
+      type: 'end',
+      meta: { position: { x: 800, y: 0 } },
+    });
+
+    const line = linesManager.createLine({ from: 'start_0', to: 'end_0' })!;
+    const renderData = line.getData(WorkflowLineRenderData);
+
+    renderData.update();
+    const path = renderData.path;
+    expect(path).not.toBe('');
+
+    // A redundant update with an unchanged position must be a no-op for a line that
+    // already has a path, preserving the original performance optimization.
+    renderData.update();
+    expect(renderData.path).toBe(path);
+  });
+});

--- a/packages/canvas-engine/free-layout-core/src/entity-datas/workflow-line-render-data.ts
+++ b/packages/canvas-engine/free-layout-core/src/entity-datas/workflow-line-render-data.ts
@@ -71,7 +71,12 @@ export class WorkflowLineRenderData extends EntityData<WorkflowLineRenderDataSch
     const oldVersion = this.data.version;
     this.updatePosition();
     const newVersion = this.data.version;
-    if (oldVersion === newVersion) {
+    // Skip recomputation only when the version is unchanged AND a path has already
+    // been computed. When a line entity is created before its line contribution is
+    // registered, the first update() sets the version while currentLine is still
+    // undefined, leaving the path empty. The `&& this.currentLine?.path` check lets a
+    // line with an empty path be recomputed once its contribution becomes available.
+    if (oldVersion === newVersion && this.currentLine?.path) {
       return;
     }
     this.data.version = newVersion;


### PR DESCRIPTION
## Summary
In the free layout editor, some connection lines fail to render (their SVG `path`
stays empty) after loading a graph via `fromJSON`. It only happens on initial load —
dragging nodes or creating connections manually works fine. Same problem as #1070.

## Root cause
`WorkflowLineRenderData.update()` skips recomputation when the position `version` is
unchanged (a performance optimization), and `path` comes from the line contribution:
`get path() { return this.currentLine?.path ?? ''; }`.

When a line entity is created **before** its line contribution (bezier/fold/straight,
registered by `free-lines-plugin` in `onReady`) is available:

1. The first `update()` writes the real coordinates into `version`, but `currentLine`
   is still `undefined`, so `path` is left empty.
2. Once the contribution registers, the coordinates are unchanged, so the recomputed
   `version` equals the stored one.
3. `oldVersion === newVersion` is true, the guard returns early, `currentLine.update()`
   is never called, and the empty `path` is locked in permanently — the line never
   renders.

This matches #1070's observation that it's specific to initial `fromJSON` loading
(manual drag/connect happens after contributions are registered).

## Fix
Skip recomputation only when the version is unchanged **and** a path has already been
computed:

```ts
if (oldVersion === newVersion && this.currentLine?.path) {
  return;
}
```

A line whose `path` is still empty is recomputed once its contribution becomes
available. Lines that already have a non-empty `path` are unaffected, preserving the
original optimization.

## Testing
Added `__tests__/workflow-line-render-data.test.ts`:

- Regression test reproducing the late-contribution case — verified red/green:
  **fails without the fix** (`path` stays `''`), **passes with the fix**.
- Guard test: a redundant `update()` on a line that already has a path is a no-op.

`rush build --to @flowgram.ai/free-layout-core` succeeds; free-layout-core tests all
pass (86 cases, incl. the 2 new ones).

Refs #1070
