### PR TITLE
perf(canvas): pan via transform:translate3d instead of left/top

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upgrade npm for OIDC support
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11
           npm --version
 
       - name: Determine version and publish parameters

--- a/packages/canvas-engine/core/src/core/layer/config/playground-config-entity.ts
+++ b/packages/canvas-engine/core/src/core/layer/config/playground-config-entity.ts
@@ -38,6 +38,9 @@ export interface PlaygroundConfigEntityData {
   scrollDisable: boolean
   grabDisable: boolean // 禁用抓取拖拽画布能力
   zoomDisable: boolean
+  viewportCulling: boolean
+  viewportCullingOverscan: number
+  lineViewportCulling: boolean
 }
 
 export interface PlaygroundConfigRevealOpts {
@@ -134,6 +137,9 @@ export class PlaygroundConfigEntity extends ConfigEntity<PlaygroundConfigEntityD
       grabDisable: false,
       scrollDisable: false,
       zoomDisable: false,
+      viewportCulling: true,
+      viewportCullingOverscan: 300,
+      lineViewportCulling: true,
       mouseScrollDelta: MOUSE_SCROLL_DELTA
     }
   }

--- a/packages/canvas-engine/core/src/core/layer/playground-layer.ts
+++ b/packages/canvas-engine/core/src/core/layer/playground-layer.ts
@@ -520,11 +520,16 @@ export class PlaygroundLayer extends Layer<PlaygroundLayerOptions> {
     //   });
     // } else {
     // }
+    // 画布平移改用 transform: translate3d 实现（合成器层，不触发 layout/paint），
+    // 替代原先的 left/top（layout-inducing 属性，会导致整棵子树每帧重排）。
+    // 坐标换算全部基于 config.scrollX/scrollY，与 DOM offset 无关，因此该改动对可视结果完全等价。
     domUtils.setStyle(this.pipelineNode, {
-      left: -playgroundConfig.scrollX,
-      top: -playgroundConfig.scrollY,
+      left: 0,
+      top: 0,
       width: playgroundConfig.width,
       height: playgroundConfig.height,
+      transform: `translate3d(${-playgroundConfig.scrollX}px, ${-playgroundConfig.scrollY}px, 0)`,
+      willChange: 'transform',
     });
     this.playgroundNode.style.cursor = finalCursor;
     // Note: 为什么要通过 style 注入样式

--- a/packages/canvas-engine/core/src/core/layer/playground-layer.ts
+++ b/packages/canvas-engine/core/src/core/layer/playground-layer.ts
@@ -42,6 +42,15 @@ export interface PlaygroundLayerOptions extends LayerOptions {
     updateHoverPosition: (position: PositionSchema, target?: HTMLElement) => void;
     clearHovered: () => void;
   };
+
+  /** Whether node DOM / React rendering should be culled outside the viewport. */
+  viewportCulling?: boolean;
+
+  /** Extra canvas-space margin around the viewport for node / line culling. */
+  viewportCullingOverscan?: number;
+
+  /** Whether free-layout lines should be culled outside the viewport. */
+  lineViewportCulling?: boolean;
 }
 
 /**
@@ -79,6 +88,11 @@ export class PlaygroundLayer extends Layer<PlaygroundLayerOptions> {
       preventGlobalGesture: false,
       ...this.options,
     };
+    this.playgroundConfigEntity.updateConfig({
+      viewportCulling: this.options.viewportCulling ?? true,
+      viewportCullingOverscan: this.options.viewportCullingOverscan ?? 300,
+      lineViewportCulling: this.options.lineViewportCulling ?? true,
+    });
     /**
      * 阻止默认的浏览器手势缩放
      */

--- a/packages/canvas-engine/free-layout-core/__tests__/workflow-lines-manager.test.ts
+++ b/packages/canvas-engine/free-layout-core/__tests__/workflow-lines-manager.test.ts
@@ -4,6 +4,8 @@
  */
 
 import { interfaces } from 'inversify';
+import { Rectangle } from '@flowgram.ai/utils';
+import { FlowNodeTransformData } from '@flowgram.ai/document';
 
 import {
   WorkflowLinesManager,
@@ -391,6 +393,53 @@ describe('workflow-lines-manager', () => {
 
     line.drawingFrom = { x: -120, y: 0, location: 'right' };
     expect(outputPortB.allLines).toEqual([]);
+  });
+
+  it('uses spatial hit testing for many nodes and updates after node moves', () => {
+    for (let i = 0; i < 140; i += 1) {
+      document.createWorkflowNode({
+        id: `bulk_${i}`,
+        type: 'start',
+        meta: {
+          position: { x: i * 1000, y: 1000 },
+        },
+      });
+    }
+
+    const target = document.getNode('bulk_139')!;
+    expect(linesManager.getNodeFromMousePos({ x: 139000, y: 1000 })).toBe(target);
+
+    target.getData<FlowNodeTransformData>(FlowNodeTransformData).position = { x: 10, y: 10 };
+
+    expect(linesManager.getNodeFromMousePos({ x: 139000, y: 1000 })).not.toBe(target);
+    expect(linesManager.getNodeFromMousePos({ x: 10, y: 10 })).toBe(target);
+  });
+
+  it('uses spatial hit testing for line viewport candidates', () => {
+    for (let i = 0; i < 140; i += 1) {
+      document.createWorkflowNode({
+        id: `line_start_${i}`,
+        type: 'start',
+        meta: {
+          position: { x: i * 1000, y: 2000 },
+        },
+      });
+      document.createWorkflowNode({
+        id: `line_end_${i}`,
+        type: 'end',
+        meta: {
+          position: { x: i * 1000 + 200, y: 2000 },
+        },
+      });
+      const line = linesManager.createLine({
+        from: `line_start_${i}`,
+        to: `line_end_${i}`,
+      })!;
+      line.getData(WorkflowLineRenderData).update();
+    }
+
+    const candidates = linesManager.getLineCandidatesByBounds(new Rectangle(139000, 1980, 400, 80));
+    expect(candidates.map((line) => line.id)).toEqual(['line_start_139_-line_end_139_']);
   });
 
   describe('flowing line support', () => {

--- a/packages/canvas-engine/free-layout-core/src/workflow-lines-manager.ts
+++ b/packages/canvas-engine/free-layout-core/src/workflow-lines-manager.ts
@@ -5,7 +5,7 @@
 
 import { last } from 'lodash-es';
 import { inject, injectable } from 'inversify';
-import { DisposableCollection, Emitter, type IPoint } from '@flowgram.ai/utils';
+import { DisposableCollection, Emitter, type IPoint, Rectangle } from '@flowgram.ai/utils';
 import { FlowNodeRenderData, FlowNodeTransformData } from '@flowgram.ai/document';
 import { EntityManager, PlaygroundConfigEntity } from '@flowgram.ai/core';
 
@@ -32,12 +32,76 @@ import { WorkflowNodeLinesData } from './entity-datas/workflow-node-lines-data';
 import { WorkflowLineRenderData } from './entity-datas';
 import {
   LINE_HOVER_DISTANCE,
+  PORT_SIZE,
   WorkflowLineEntity,
   type WorkflowLineInfo,
   type WorkflowLinePortInfo,
-  type WorkflowNodeEntity,
+  WorkflowNodeEntity,
   WorkflowPortEntity,
 } from './entities';
+
+const SPATIAL_INDEX_THRESHOLD = 128;
+const SPATIAL_INDEX_CELL_SIZE = 512;
+
+class SpatialIndex<T> {
+  private cells = new Map<string, T[]>();
+
+  constructor(
+    private readonly items: T[],
+    private readonly getBounds: (item: T) => Rectangle | undefined,
+    private readonly cellSize = SPATIAL_INDEX_CELL_SIZE
+  ) {
+    this.rebuild();
+  }
+
+  search(bounds: Rectangle): T[] {
+    const result: T[] = [];
+    const seen = new Set<T>();
+    this.forEachCell(bounds, (key) => {
+      const items = this.cells.get(key);
+      if (!items) {
+        return;
+      }
+      items.forEach((item) => {
+        if (seen.has(item)) {
+          return;
+        }
+        const itemBounds = this.getBounds(item);
+        if (itemBounds && Rectangle.isViewportVisible(itemBounds, bounds)) {
+          seen.add(item);
+          result.push(item);
+        }
+      });
+    });
+    return result;
+  }
+
+  private rebuild(): void {
+    this.items.forEach((item) => {
+      const bounds = this.getBounds(item);
+      if (!bounds) {
+        return;
+      }
+      this.forEachCell(bounds, (key) => {
+        const items = this.cells.get(key) || [];
+        items.push(item);
+        this.cells.set(key, items);
+      });
+    });
+  }
+
+  private forEachCell(bounds: Rectangle, fn: (key: string) => void): void {
+    const minX = Math.floor(bounds.left / this.cellSize);
+    const maxX = Math.floor(bounds.right / this.cellSize);
+    const minY = Math.floor(bounds.top / this.cellSize);
+    const maxY = Math.floor(bounds.bottom / this.cellSize);
+    for (let x = minX; x <= maxX; x += 1) {
+      for (let y = minY; y <= maxY; y += 1) {
+        fn(`${x}:${y}`);
+      }
+    }
+  }
+}
 
 /**
  * 线条管理
@@ -77,6 +141,18 @@ export class WorkflowLinesManager {
   readonly onForceUpdate = this.onForceUpdateEmitter.event;
 
   readonly contributionFactories: WorkflowLineRenderContributionFactory[] = [];
+
+  private nodeIndex?: SpatialIndex<WorkflowNodeEntity>;
+
+  private nodeIndexSignature = '';
+
+  private lineIndex?: SpatialIndex<WorkflowLineEntity>;
+
+  private lineIndexSignature = '';
+
+  private portIndexByType = new Map<string, SpatialIndex<WorkflowPortEntity>>();
+
+  private portIndexSignature = '';
 
   init(doc: WorkflowDocument): void {
     this.document = doc;
@@ -327,7 +403,7 @@ export class WorkflowLinesManager {
     minDistance: number = LINE_HOVER_DISTANCE
   ): WorkflowLineEntity | undefined {
     let targetLine: WorkflowLineEntity | undefined, targetLineDist: number | undefined;
-    this.getAllLines().forEach((line) => {
+    this.getLineCandidates(mousePos, minDistance).forEach((line) => {
       const dist = line.getHoverDist(mousePos);
 
       if (dist <= minDistance && (!targetLineDist || targetLineDist >= dist)) {
@@ -336,6 +412,14 @@ export class WorkflowLinesManager {
       }
     });
     return targetLine;
+  }
+
+  getLineCandidatesByBounds(bounds: Rectangle): WorkflowLineEntity[] {
+    const allLines = this.getAllLines();
+    if (allLines.length < SPATIAL_INDEX_THRESHOLD) {
+      return allLines.filter((line) => Rectangle.isViewportVisible(line.bounds, bounds));
+    }
+    return this.getLineIndex().search(bounds);
   }
 
   /**
@@ -503,15 +587,7 @@ export class WorkflowLinesManager {
    * @param pos
    */
   getPortFromMousePos(pos: IPoint, portType?: WorkflowPortType): WorkflowPortEntity | undefined {
-    const allNodes = this.getSortedNodes().reverse();
-    const allPorts = allNodes
-      .map((node) => {
-        if (!portType) {
-          return node.ports.allPorts;
-        }
-        return portType === 'input' ? node.ports.inputPorts : node.ports.outputPorts;
-      })
-      .flat();
+    const allPorts = this.getPortCandidates(pos, portType);
     const targetPort = allPorts.find((port) => port.isHovered(pos.x, pos.y));
     if (targetPort) {
       const containNodes = this.getContainNodesFromMousePos(pos);
@@ -559,8 +635,8 @@ export class WorkflowLinesManager {
   }
 
   /** 获取鼠标坐标位置的所有节点（stackIndex 从小到大排序） */
-  private getContainNodesFromMousePos(pos: IPoint): WorkflowNodeEntity[] {
-    const allNodes = this.getSortedNodes();
+  getContainNodesFromMousePos(pos: IPoint): WorkflowNodeEntity[] {
+    const allNodes = this.getNodeCandidates(pos);
     const zoom =
       this.entityManager.getEntity<PlaygroundConfigEntity>(PlaygroundConfigEntity)?.config?.zoom ||
       1;
@@ -578,7 +654,91 @@ export class WorkflowLinesManager {
         }
       })
       .filter(Boolean) as WorkflowNodeEntity[];
+    containNodes.sort((a, b) => this.getNodeIndex(a) - this.getNodeIndex(b));
     return containNodes;
+  }
+
+  private getNodeCandidates(pos: IPoint): WorkflowNodeEntity[] {
+    if (this.entityManager.getEntities(WorkflowNodeEntity).length < SPATIAL_INDEX_THRESHOLD) {
+      return this.getSortedNodes();
+    }
+    const zoom =
+      this.entityManager.getEntity<PlaygroundConfigEntity>(PlaygroundConfigEntity)?.config?.zoom ||
+      1;
+    return this.getNodeIndexCache().search(new Rectangle(pos.x, pos.y, 0, 0).pad(4 / zoom));
+  }
+
+  private getPortCandidates(pos: IPoint, portType?: WorkflowPortType): WorkflowPortEntity[] {
+    const allPorts = this.getAllPorts(portType);
+    if (allPorts.length < SPATIAL_INDEX_THRESHOLD) {
+      return allPorts;
+    }
+    return this.getPortIndex(portType).search(new Rectangle(pos.x, pos.y, 0, 0).pad(PORT_SIZE));
+  }
+
+  private getLineCandidates(pos: IPoint, minDistance: number): WorkflowLineEntity[] {
+    const allLines = this.getAllLines();
+    if (allLines.length < SPATIAL_INDEX_THRESHOLD) {
+      return allLines;
+    }
+    return this.getLineIndex().search(new Rectangle(pos.x, pos.y, 0, 0).pad(minDistance));
+  }
+
+  private getAllPorts(portType?: WorkflowPortType): WorkflowPortEntity[] {
+    const nodes = this.getSortedNodes().reverse();
+    return nodes
+      .map((node) => {
+        if (!portType) {
+          return node.ports.allPorts;
+        }
+        return portType === 'input' ? node.ports.inputPorts : node.ports.outputPorts;
+      })
+      .flat();
+  }
+
+  private getNodeIndexCache(): SpatialIndex<WorkflowNodeEntity> {
+    const signature = [
+      this.entityManager.getEntityVersion(WorkflowNodeEntity),
+      this.entityManager.getEntityDataVersion(FlowNodeTransformData),
+    ].join('|');
+    if (!this.nodeIndex || this.nodeIndexSignature !== signature) {
+      this.nodeIndexSignature = signature;
+      this.nodeIndex = new SpatialIndex(
+        this.getSortedNodes(),
+        (node) => node.getData<FlowNodeTransformData>(FlowNodeTransformData)?.bounds
+      );
+    }
+    return this.nodeIndex;
+  }
+
+  private getPortIndex(portType?: WorkflowPortType): SpatialIndex<WorkflowPortEntity> {
+    const key = portType || 'all';
+    const signature = [
+      this.entityManager.getEntityVersion(WorkflowPortEntity),
+      this.entityManager.getEntityDataVersion(FlowNodeTransformData),
+    ].join('|');
+    if (this.portIndexSignature !== signature) {
+      this.portIndexSignature = signature;
+      this.portIndexByType.clear();
+    }
+    let index = this.portIndexByType.get(key);
+    if (!index) {
+      index = new SpatialIndex(this.getAllPorts(portType), (port) => port.bounds);
+      this.portIndexByType.set(key, index);
+    }
+    return index;
+  }
+
+  private getLineIndex(): SpatialIndex<WorkflowLineEntity> {
+    const signature = [
+      this.entityManager.getEntityVersion(WorkflowLineEntity),
+      this.entityManager.getEntityDataVersion(WorkflowLineRenderData),
+    ].join('|');
+    if (!this.lineIndex || this.lineIndexSignature !== signature) {
+      this.lineIndexSignature = signature;
+      this.lineIndex = new SpatialIndex(this.getAllLines(), (line) => line.bounds);
+    }
+    return this.lineIndex;
   }
 
   private getNodeIndex(node: WorkflowNodeEntity): number {

--- a/packages/canvas-engine/renderer/__tests__/layers/flow-transform-layer.test.tsx
+++ b/packages/canvas-engine/renderer/__tests__/layers/flow-transform-layer.test.tsx
@@ -9,9 +9,12 @@ import {
   FlowDocument,
   FlowDocumentContainerModule,
   FlowDocumentContribution,
+  FlowNodeRenderData,
+  FlowNodeTransformData,
 } from '@flowgram.ai/document';
 import {
   createDefaultPlaygroundConfig,
+  PlaygroundConfigEntity,
   PlaygroundConfig,
   PlaygroundContainerModule,
 } from '@flowgram.ai/core';
@@ -70,7 +73,7 @@ describe('flow-transform-layer', () => {
 
   // 测试初始化
   it('test ready', () => {
-    registry.pipeline.renderer.layers.forEach(layer => {
+    registry.pipeline.renderer.layers.forEach((layer) => {
       (layer as FlowNodesTransformLayer).onReady();
       expect(layer.node.style.zIndex).toEqual('10');
     });
@@ -78,7 +81,7 @@ describe('flow-transform-layer', () => {
 
   // 缩放
   it('test zoom', () => {
-    registry.pipeline.renderer.layers.forEach(layer => {
+    registry.pipeline.renderer.layers.forEach((layer) => {
       (layer as FlowNodesTransformLayer).onZoom(2);
       expect(layer.node!.style.transform).toEqual('scale(2)');
     });
@@ -87,10 +90,116 @@ describe('flow-transform-layer', () => {
   // FIXME: render 单测目前不全
   // 渲染
   it('test render', () => {
-    registry.pipeline.renderer.layers.forEach(layer => {
+    registry.pipeline.renderer.layers.forEach((layer) => {
       // const autorun = registry.pipeline.renderer.layerAutorunMap.get(layer);
       // autorun?.();
       (layer as FlowNodesTransformLayer).updateNodesBounds();
     });
+  });
+
+  it('culls transform host dom outside viewport and remounts when visible', () => {
+    const layer = registry.pipeline.renderer.layers[0] as FlowNodesTransformLayer;
+    layer.onReady();
+    (layer as any).config.updateConfig({
+      width: 100,
+      height: 100,
+      viewportCulling: true,
+      viewportCullingOverscan: 0,
+    });
+    document.transformer.refresh();
+    const nodes = document
+      .getAllNodes()
+      .filter((node) => node.id !== 'root')
+      .sort(
+        (a, b) =>
+          a.getData<FlowNodeTransformData>(FlowNodeTransformData).bounds.x -
+          b.getData<FlowNodeTransformData>(FlowNodeTransformData).bounds.x
+      );
+    const visibleNode = nodes[0];
+    const hiddenNode = nodes[nodes.length - 1];
+    const visibleBounds = visibleNode.getData<FlowNodeTransformData>(FlowNodeTransformData).bounds;
+    const hiddenBounds = hiddenNode.getData<FlowNodeTransformData>(FlowNodeTransformData).bounds;
+    (layer as any).config.updateConfig({
+      scrollX: visibleBounds.x,
+      scrollY: visibleBounds.y,
+    });
+
+    layer.updateNodesBounds();
+
+    expect(visibleNode.getData<FlowNodeRenderData>(FlowNodeRenderData).node.parentElement).toBe(
+      layer.node
+    );
+    expect(
+      hiddenNode.getData<FlowNodeRenderData>(FlowNodeRenderData).node.parentElement
+    ).toBeNull();
+
+    (layer as any).config.updateConfig({
+      scrollX: hiddenBounds.x,
+      scrollY: hiddenBounds.y,
+    });
+    layer.updateNodesBounds();
+
+    expect(hiddenNode.getData<FlowNodeRenderData>(FlowNodeRenderData).node.parentElement).toBe(
+      layer.node
+    );
+  });
+
+  it('keeps interactive offscreen transform host mounted', () => {
+    const layer = registry.pipeline.renderer.layers[0] as FlowNodesTransformLayer;
+    layer.onReady();
+    (layer as any).config.updateConfig({
+      width: 100,
+      height: 100,
+      viewportCulling: true,
+      viewportCullingOverscan: 0,
+    });
+    const node = document.getAllNodes().find((n) => n.id !== 'root')!;
+    document.transformer.refresh();
+    const bounds = node.getData<FlowNodeTransformData>(FlowNodeTransformData).bounds;
+    (layer as any).config.updateConfig({
+      scrollX: bounds.x + 1000,
+      scrollY: bounds.y + 1000,
+    });
+    node.getData<FlowNodeRenderData>(FlowNodeRenderData).activated = true;
+
+    layer.updateNodesBounds();
+
+    expect(node.getData<FlowNodeRenderData>(FlowNodeRenderData).node.parentElement).toBe(
+      layer.node
+    );
+  });
+
+  it('culls offscreen transform host when auto resize is disabled', () => {
+    const layer = registry.pipeline.renderer.layers[0] as FlowNodesTransformLayer;
+    layer.onReady();
+    (layer as any).config.updateConfig({
+      width: 100,
+      height: 100,
+      viewportCulling: true,
+      viewportCullingOverscan: 0,
+    });
+    const node = document.getAllNodes().find((n) => n.id !== 'root')!;
+    vi.spyOn(node, 'getNodeMeta').mockReturnValue({
+      ...node.getNodeMeta(),
+      autoResizeDisable: true,
+    });
+    document.transformer.refresh();
+    const bounds = node.getData<FlowNodeTransformData>(FlowNodeTransformData).bounds;
+    (layer as any).config.updateConfig({
+      scrollX: bounds.x,
+      scrollY: bounds.y,
+    });
+    layer.updateNodesBounds();
+    expect(node.getData<FlowNodeRenderData>(FlowNodeRenderData).node.parentElement).toBe(
+      layer.node
+    );
+
+    (layer as any).config.updateConfig({
+      scrollX: bounds.x + 1000,
+      scrollY: bounds.y + 1000,
+    });
+    layer.updateNodesBounds();
+
+    expect(node.getData<FlowNodeRenderData>(FlowNodeRenderData).node.parentElement).toBeNull();
   });
 });

--- a/packages/canvas-engine/renderer/src/index.ts
+++ b/packages/canvas-engine/renderer/src/index.ts
@@ -10,6 +10,12 @@ export * from './flow-renderer-registry';
 export * from './flow-renderer-container-module';
 
 export { ScrollBarEvents } from './utils';
+export {
+  getExpandedViewport,
+  getViewportCullingConfig,
+  isBoundsVisible,
+  type ViewportCullingConfig,
+} from './utils';
 export { MARK_ARROW_ID } from './components/MarkerArrow';
 export { MARK_ACTIVATED_ARROW_ID } from './components/MarkerActivatedArrow';
 export { useBaseColor } from './hooks/use-base-color';

--- a/packages/canvas-engine/renderer/src/layers/flow-context-menu-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-context-menu-layer.tsx
@@ -87,8 +87,10 @@ export class FlowContextMenuLayer extends Layer {
 
           this.nodeRef.current?.setVisible(true);
           const clientBounds = this.playgroundConfigEntity.getClientBounds();
-          const dragBlockX = e.clientX - (this.pipelineNode.offsetLeft || 0) - clientBounds.x;
-          const dragBlockY = e.clientY - (this.pipelineNode.offsetTop || 0) - clientBounds.y;
+          // 画布平移已改用 transform，offsetLeft/offsetTop 不再反映滚动偏移，
+          // 用 config.scrollX/scrollY 代替（原 offsetLeft = -scrollX，故此处为 + scrollX）
+          const dragBlockX = e.clientX + this.playgroundConfigEntity.config.scrollX - clientBounds.x;
+          const dragBlockY = e.clientY + this.playgroundConfigEntity.config.scrollY - clientBounds.y;
           this.node.style.left = `${dragBlockX}px`;
           this.node.style.top = `${dragBlockY}px`;
         },

--- a/packages/canvas-engine/renderer/src/layers/flow-debug-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-debug-layer.tsx
@@ -78,7 +78,7 @@ export class FlowDebugLayer extends Layer {
       position: 'absolute',
       width: 1,
       height: '100%',
-      left: this.pipelineNode.style.left,
+      left: `${-this.config.config.scrollX}px`,
       top: 0,
       borderLeft: '1px dashed rgba(255, 0, 0, 0.5)',
     });
@@ -91,7 +91,7 @@ export class FlowDebugLayer extends Layer {
   }
 
   onScroll() {
-    this.originLine.style.left = this.pipelineNode.style.left;
+    this.originLine.style.left = `${-this.config.config.scrollX}px`;
     this.renderScrollViewportBounds();
   }
 

--- a/packages/canvas-engine/renderer/src/layers/flow-drag-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-drag-layer.tsx
@@ -188,13 +188,13 @@ export class FlowDragLayer extends Layer<FlowDragOptions> {
         }
         const clientBounds = this.playgroundConfigEntity.getClientBounds();
         const dragBlockX =
-          event.clientX -
-          -this.playgroundConfigEntity.config.scrollX -
+          event.clientX +
+          this.playgroundConfigEntity.config.scrollX -
           clientBounds.x -
           (dragNode.clientWidth - this.dragOffset.x) * scale;
         const dragBlockY =
-          event.clientY -
-          -this.playgroundConfigEntity.config.scrollY -
+          event.clientY +
+          this.playgroundConfigEntity.config.scrollY -
           clientBounds.y -
           (dragNode.clientHeight - this.dragOffset.y) * scale;
 

--- a/packages/canvas-engine/renderer/src/layers/flow-drag-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-drag-layer.tsx
@@ -189,12 +189,12 @@ export class FlowDragLayer extends Layer<FlowDragOptions> {
         const clientBounds = this.playgroundConfigEntity.getClientBounds();
         const dragBlockX =
           event.clientX -
-          (this.pipelineNode.offsetLeft || 0) -
+          -this.playgroundConfigEntity.config.scrollX -
           clientBounds.x -
           (dragNode.clientWidth - this.dragOffset.x) * scale;
         const dragBlockY =
           event.clientY -
-          (this.pipelineNode.offsetTop || 0) -
+          -this.playgroundConfigEntity.config.scrollY -
           clientBounds.y -
           (dragNode.clientHeight - this.dragOffset.y) * scale;
 
@@ -248,10 +248,10 @@ export class FlowDragLayer extends Layer<FlowDragOptions> {
         this.pipelineNode.parentElement!.appendChild(this.draggingNodeMask);
 
         this.containerRef.current.style.left = `${
-          dragBlockX + this.pipelineNode.offsetLeft + clientBounds.x + window.scrollX
+          dragBlockX - this.playgroundConfigEntity.config.scrollX + clientBounds.x + window.scrollX
         }px`;
         this.containerRef.current.style.top = `${
-          dragBlockY + this.pipelineNode.offsetTop + clientBounds.y + window.scrollY
+          dragBlockY - this.playgroundConfigEntity.config.scrollY + clientBounds.y + window.scrollY
         }px`;
         this.containerRef.current.style.transformOrigin = 'top left';
         this.containerRef.current.style.transform = `scale(${scale})`;

--- a/packages/canvas-engine/renderer/src/layers/flow-nodes-content-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-nodes-content-layer.tsx
@@ -47,7 +47,11 @@ const NodePortal = React.memo(function NodePortal(props: NodePortalProps): JSX.E
   const { entity, container, version, activated, readonly, disabled, Renderer } = props;
   React.useEffect(() => {
     // 首次挂载（或重新进入视口挂载）时把真实宽高回写到 transform 数据
-    if (!entity.getNodeMeta().autoResizeDisable && container.clientWidth && container.clientHeight) {
+    if (
+      !entity.getNodeMeta().autoResizeDisable &&
+      container.clientWidth &&
+      container.clientHeight
+    ) {
       const transform = entity.getData<FlowNodeTransformData>(FlowNodeTransformData);
       if (transform) {
         transform.size = {
@@ -104,6 +108,14 @@ export class FlowNodesContentLayer extends Layer {
 
   private renderMemoCache = new WeakMap<any, any>();
 
+  private lastVisibleSignature = '';
+
+  private visibleRenderStatesCache: FlowNodeRenderData[] | undefined;
+
+  private lastViewportBucket = '';
+
+  private lastRenderStatesSignature = '';
+
   node = domUtils.createDivWithClass('gedit-flow-nodes-layer');
 
   getPortalRenderer(data: FlowNodeRenderData): (props: any) => JSX.Element {
@@ -142,11 +154,20 @@ export class FlowNodesContentLayer extends Layer {
   /**
    * 视口变化（平移 / 缩放 / resize）时，重算需要渲染的节点，做视口裁剪。
    *
-   * 注意：render() 已被 pipeline 重写为 forceUpdate 调度，这里直接调用即可触发
-   * 一次 re-render；且平移时 documentTransformer.refresh() 因版本未变会短路，成本极低。
+   * 平移过程的 scroll 事件频率很高，如果每次都 force render，React 仍会进入
+   * portal 列表 reconcile / commit。这里先用视口 bucket 和可见集合签名短路：
+   * 只有可见节点集合真的变化时才触发 React 更新，让常规拖拽尽量只走外层 DOM transform。
    */
   onViewportChange() {
     if (this.viewportCullDisable) return;
+    const viewportBucket = this.getViewportBucket();
+    if (viewportBucket === this.lastViewportBucket) return;
+    this.lastViewportBucket = viewportBucket;
+    const visibleRenderStates = this.collectVisibleRenderStates();
+    const visibleSignature = this.getVisibleSignature(visibleRenderStates);
+    if (visibleSignature === this.lastVisibleSignature) return;
+    this.visibleRenderStatesCache = visibleRenderStates;
+    this.lastVisibleSignature = visibleSignature;
     this.render();
   }
 
@@ -158,6 +179,26 @@ export class FlowNodesContentLayer extends Layer {
   getVisibleRenderStates(): FlowNodeRenderData[] {
     const all = this.renderStatesVisible;
     if (this.viewportCullDisable) return all;
+    const renderStatesSignature = this.getRenderStatesSignature(all);
+    if (renderStatesSignature !== this.lastRenderStatesSignature) {
+      const visibleRenderStates = this.collectVisibleRenderStates(all);
+      this.visibleRenderStatesCache = visibleRenderStates;
+      this.lastVisibleSignature = this.getVisibleSignature(visibleRenderStates);
+      this.lastViewportBucket = this.getViewportBucket();
+      this.lastRenderStatesSignature = renderStatesSignature;
+      return visibleRenderStates;
+    }
+    if (!this.visibleRenderStatesCache) {
+      const visibleRenderStates = this.collectVisibleRenderStates(all);
+      this.visibleRenderStatesCache = visibleRenderStates;
+      this.lastVisibleSignature = this.getVisibleSignature(visibleRenderStates);
+      this.lastViewportBucket = this.getViewportBucket();
+      this.lastRenderStatesSignature = renderStatesSignature;
+    }
+    return this.visibleRenderStatesCache;
+  }
+
+  private collectVisibleRenderStates(all = this.renderStatesVisible): FlowNodeRenderData[] {
     const viewport = this.config.getViewport();
     const expanded = new Rectangle(
       viewport.x - this.overscan,
@@ -174,6 +215,31 @@ export class FlowNodesContentLayer extends Layer {
       }
       return Rectangle.isViewportVisible(bounds, expanded);
     });
+  }
+
+  private getVisibleSignature(renderStates: FlowNodeRenderData[]): string {
+    return renderStates.map((data) => data.entity.id).join('|');
+  }
+
+  private getRenderStatesSignature(renderStates: FlowNodeRenderData[]): string {
+    return renderStates
+      .map(
+        (data) =>
+          `${data.entity.id}:${data.version ?? ''}:${data.activated ? 1 : 0}:${data.node ? 1 : 0}`
+      )
+      .join('|');
+  }
+
+  private getViewportBucket(): string {
+    const viewport = this.config.getViewport();
+    const bucketSize = Math.max(1, this.overscan / 2);
+    return [
+      Math.floor(viewport.x / bucketSize),
+      Math.floor(viewport.y / bucketSize),
+      Math.round(viewport.width),
+      Math.round(viewport.height),
+      Math.round(this.config.finalScale * 1000),
+    ].join('|');
   }
 
   render() {

--- a/packages/canvas-engine/renderer/src/layers/flow-nodes-content-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-nodes-content-layer.tsx
@@ -7,7 +7,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 
 import { inject, injectable } from 'inversify';
-import { domUtils, Rectangle } from '@flowgram.ai/utils';
+import { domUtils } from '@flowgram.ai/utils';
 import {
   FlowDocument,
   FlowDocumentTransformerEntity,
@@ -22,6 +22,12 @@ import {
   PlaygroundEntityContext,
 } from '@flowgram.ai/core';
 
+import {
+  getExpandedViewport,
+  getViewportCullingConfig,
+  isBoundsVisible,
+  shouldKeepNodeMounted,
+} from '../utils/viewport-culling';
 import { FlowRendererKey, FlowRendererRegistry } from '../flow-renderer-registry';
 
 interface NodePortalProps {
@@ -95,17 +101,6 @@ export class FlowNodesContentLayer extends Layer {
     return this.document.getRenderDatas<FlowNodeRenderData>(FlowNodeRenderData, false);
   }
 
-  /**
-   * 是否关闭视口裁剪（虚拟化）。默认开启；如需回退旧的「全量渲染」行为，
-   * 可在子类或注册时置为 true。
-   */
-  protected viewportCullDisable = false;
-
-  /**
-   * 视口外预渲染边距（画布坐标，未乘 scale），用于减少快速平移时的露白 / 闪烁。
-   */
-  protected overscan = 300;
-
   private renderMemoCache = new WeakMap<any, any>();
 
   private lastVisibleSignature = '';
@@ -159,7 +154,7 @@ export class FlowNodesContentLayer extends Layer {
    * 只有可见节点集合真的变化时才触发 React 更新，让常规拖拽尽量只走外层 DOM transform。
    */
   onViewportChange() {
-    if (this.viewportCullDisable) return;
+    if (!getViewportCullingConfig(this.config).enabled) return;
     const viewportBucket = this.getViewportBucket();
     if (viewportBucket === this.lastViewportBucket) return;
     this.lastViewportBucket = viewportBucket;
@@ -178,7 +173,7 @@ export class FlowNodesContentLayer extends Layer {
    */
   getVisibleRenderStates(): FlowNodeRenderData[] {
     const all = this.renderStatesVisible;
-    if (this.viewportCullDisable) return all;
+    if (!getViewportCullingConfig(this.config).enabled) return all;
     const renderStatesSignature = this.getRenderStatesSignature(all);
     if (renderStatesSignature !== this.lastRenderStatesSignature) {
       const visibleRenderStates = this.collectVisibleRenderStates(all);
@@ -199,21 +194,17 @@ export class FlowNodesContentLayer extends Layer {
   }
 
   private collectVisibleRenderStates(all = this.renderStatesVisible): FlowNodeRenderData[] {
-    const viewport = this.config.getViewport();
-    const expanded = new Rectangle(
-      viewport.x - this.overscan,
-      viewport.y - this.overscan,
-      viewport.width + this.overscan * 2,
-      viewport.height + this.overscan * 2
-    );
+    const expanded = getExpandedViewport(this.config);
     return all.filter((data) => {
       const transform = data.entity.getData<FlowNodeTransformData>(FlowNodeTransformData);
       const bounds = transform?.bounds;
       // 尺寸 / 位置未知（尚未测量）的节点先保留，避免首屏布局丢失
-      if (!bounds || (bounds.width === 0 && bounds.height === 0)) {
-        return true;
-      }
-      return Rectangle.isViewportVisible(bounds, expanded);
+      return (
+        !transform ||
+        shouldKeepNodeMounted(transform, this.document) ||
+        !bounds ||
+        isBoundsVisible(bounds, expanded)
+      );
     });
   }
 
@@ -225,14 +216,16 @@ export class FlowNodesContentLayer extends Layer {
     return renderStates
       .map(
         (data) =>
-          `${data.entity.id}:${data.version ?? ''}:${data.activated ? 1 : 0}:${data.node ? 1 : 0}`
+          `${data.entity.id}:${data.version ?? ''}:${data.activated ? 1 : 0}:${
+            data.hovered ? 1 : 0
+          }:${data.dragging ? 1 : 0}`
       )
       .join('|');
   }
 
   private getViewportBucket(): string {
     const viewport = this.config.getViewport();
-    const bucketSize = Math.max(1, this.overscan / 2);
+    const bucketSize = Math.max(1, getViewportCullingConfig(this.config).overscan / 2);
     return [
       Math.floor(viewport.x / bucketSize),
       Math.floor(viewport.y / bucketSize),

--- a/packages/canvas-engine/renderer/src/layers/flow-nodes-content-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-nodes-content-layer.tsx
@@ -7,7 +7,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 
 import { inject, injectable } from 'inversify';
-import { Cache, type CacheOriginItem, domUtils } from '@flowgram.ai/utils';
+import { domUtils, Rectangle } from '@flowgram.ai/utils';
 import {
   FlowDocument,
   FlowDocumentTransformerEntity,
@@ -24,10 +24,53 @@ import {
 
 import { FlowRendererKey, FlowRendererRegistry } from '../flow-renderer-registry';
 
-interface NodePortal extends CacheOriginItem {
-  id: string;
-  Portal: () => JSX.Element;
+interface NodePortalProps {
+  entity: FlowNodeEntity;
+  /** 节点内容挂载的宿主 DOM（由 transform layer 创建并定位） */
+  container: HTMLElement;
+  version: number | undefined;
+  activated: boolean | undefined;
+  readonly: boolean;
+  disabled: boolean;
+  Renderer: (props: any) => JSX.Element;
 }
+
+/**
+ * 单个节点的 Portal 组件。
+ *
+ * 关键点：用 React.memo 做「每节点」级别的隔离。父层（FlowNodesContentLayer）在
+ * 任意节点数据变化或视口变化时都会整体 re-render，但只有 version / activated /
+ * readonly / disabled 真正变化的节点才会重新渲染并进入 React commit，其余节点
+ * 直接 bail-out，避免 O(N) 的 createPortal / reconcile 开销。
+ */
+const NodePortal = React.memo(function NodePortal(props: NodePortalProps): JSX.Element {
+  const { entity, container, version, activated, readonly, disabled, Renderer } = props;
+  React.useEffect(() => {
+    // 首次挂载（或重新进入视口挂载）时把真实宽高回写到 transform 数据
+    if (!entity.getNodeMeta().autoResizeDisable && container.clientWidth && container.clientHeight) {
+      const transform = entity.getData<FlowNodeTransformData>(FlowNodeTransformData);
+      if (transform) {
+        transform.size = {
+          width: container.clientWidth,
+          height: container.clientHeight,
+        };
+      }
+    }
+  }, [entity, container]);
+  // 这里使用 portal，改 dom 样式不会引起 react 重新渲染
+  return ReactDOM.createPortal(
+    <PlaygroundEntityContext.Provider value={entity}>
+      <Renderer
+        node={entity}
+        version={version}
+        activated={activated}
+        readonly={readonly}
+        disabled={disabled}
+      />
+    </PlaygroundEntityContext.Provider>,
+    container
+  );
+});
 
 /**
  * 渲染节点内容
@@ -47,6 +90,17 @@ export class FlowNodesContentLayer extends Layer {
   get renderStatesVisible(): FlowNodeRenderData[] {
     return this.document.getRenderDatas<FlowNodeRenderData>(FlowNodeRenderData, false);
   }
+
+  /**
+   * 是否关闭视口裁剪（虚拟化）。默认开启；如需回退旧的「全量渲染」行为，
+   * 可在子类或注册时置为 true。
+   */
+  protected viewportCullDisable = false;
+
+  /**
+   * 视口外预渲染边距（画布坐标，未乘 scale），用于减少快速平移时的露白 / 闪烁。
+   */
+  protected overscan = 300;
 
   private renderMemoCache = new WeakMap<any, any>();
 
@@ -74,54 +128,6 @@ export class FlowNodesContentLayer extends Layer {
     this.node!.style.transform = `scale(${scale})`;
   }
 
-  dispose(): void {
-    this.reactPortals.dispose();
-    super.dispose();
-  }
-
-  protected reactPortals = Cache.create<NodePortal, FlowNodeRenderData>(
-    (data?: FlowNodeRenderData) => {
-      const { node, entity } = data!;
-      const { config } = this;
-      const PortalRenderer = this.getPortalRenderer(data!);
-
-      function Portal(): JSX.Element {
-        React.useEffect(() => {
-          // 第一次加载需要把宽高通知
-          if (!entity.getNodeMeta().autoResizeDisable && node.clientWidth && node.clientHeight) {
-            const transform = entity.getData<FlowNodeTransformData>(FlowNodeTransformData);
-            if (transform)
-              transform.size = {
-                width: node.clientWidth,
-                height: node.clientHeight,
-              };
-          }
-        }, [entity, node]);
-        // 这里使用 portal，改 dom 样式不会引起 react 重新渲染
-        return ReactDOM.createPortal(
-          <PlaygroundEntityContext.Provider value={entity}>
-            <PortalRenderer
-              node={entity}
-              version={data?.version}
-              activated={data?.activated}
-              readonly={config.readonly}
-              disabled={config.disabled}
-            />
-          </PlaygroundEntityContext.Provider>,
-          node
-        );
-      }
-
-      return {
-        id: node.id || entity.id,
-        dispose: () => {
-          // TODO, 删除逻辑由 node 去控制了
-        },
-        Portal,
-      } as NodePortal;
-    }
-  );
-
   onReady() {
     this.node!.style.zIndex = '10';
   }
@@ -133,19 +139,63 @@ export class FlowNodesContentLayer extends Layer {
     this.render();
   }
 
-  getPortals(): NodePortal[] {
-    return this.reactPortals.getMoreByItems(this.renderStatesVisible);
+  /**
+   * 视口变化（平移 / 缩放 / resize）时，重算需要渲染的节点，做视口裁剪。
+   *
+   * 注意：render() 已被 pipeline 重写为 forceUpdate 调度，这里直接调用即可触发
+   * 一次 re-render；且平移时 documentTransformer.refresh() 因版本未变会短路，成本极低。
+   */
+  onViewportChange() {
+    if (this.viewportCullDisable) return;
+    this.render();
+  }
+
+  /**
+   * 仅返回视口内（含 overscan）需要渲染的节点。
+   * 离屏节点不生成 Portal，其内容 DOM 会被 React 卸载，从而大幅降低同屏
+   * DOM 数量与 React commit 阶段的挂载 / reconcile 开销。
+   */
+  getVisibleRenderStates(): FlowNodeRenderData[] {
+    const all = this.renderStatesVisible;
+    if (this.viewportCullDisable) return all;
+    const viewport = this.config.getViewport();
+    const expanded = new Rectangle(
+      viewport.x - this.overscan,
+      viewport.y - this.overscan,
+      viewport.width + this.overscan * 2,
+      viewport.height + this.overscan * 2
+    );
+    return all.filter((data) => {
+      const transform = data.entity.getData<FlowNodeTransformData>(FlowNodeTransformData);
+      const bounds = transform?.bounds;
+      // 尺寸 / 位置未知（尚未测量）的节点先保留，避免首屏布局丢失
+      if (!bounds || (bounds.width === 0 && bounds.height === 0)) {
+        return true;
+      }
+      return Rectangle.isViewportVisible(bounds, expanded);
+    });
   }
 
   render() {
     if (this.documentTransformer.loading) return <></>;
     this.documentTransformer.refresh();
 
-    // 从缓存获取节点
+    const readonly = this.config.readonly;
+    const disabled = this.config.disabled;
+
     return (
       <>
-        {this.getPortals().map((portal) => (
-          <portal.Portal key={portal.id} />
+        {this.getVisibleRenderStates().map((data) => (
+          <NodePortal
+            key={data.entity.id}
+            entity={data.entity}
+            container={data.node}
+            version={data.version}
+            activated={data.activated}
+            readonly={readonly}
+            disabled={disabled}
+            Renderer={this.getPortalRenderer(data)}
+          />
         ))}
       </>
     );

--- a/packages/canvas-engine/renderer/src/layers/flow-nodes-transform-layer.tsx
+++ b/packages/canvas-engine/renderer/src/layers/flow-nodes-transform-layer.tsx
@@ -14,6 +14,12 @@ import {
 import { Layer, observeEntity, observeEntityDatas } from '@flowgram.ai/core';
 // import { throttle } from 'lodash-es'
 
+import {
+  getExpandedViewport,
+  getViewportCullingConfig,
+  isBoundsVisible,
+  shouldKeepNodeMounted,
+} from '../utils/viewport-culling';
 import { FlowRendererResizeObserver } from '../flow-renderer-resize-observer';
 
 interface TransformRenderCache {
@@ -46,6 +52,15 @@ export class FlowNodesTransformLayer extends Layer<FlowNodesTransformLayerOption
     return this.document.getRenderDatas<FlowNodeTransformData>(FlowNodeTransformData, false);
   }
 
+  get visibleTransforms(): FlowNodeTransformData[] {
+    const all = this.transformVisibles;
+    if (!getViewportCullingConfig(this.config).enabled) {
+      return all;
+    }
+    const expanded = getExpandedViewport(this.config);
+    return all.filter((transform) => this.shouldKeepTransformMounted(transform, expanded));
+  }
+
   /**
    * 监听缩放，目前采用整体缩放
    * @param scale
@@ -59,9 +74,11 @@ export class FlowNodesTransformLayer extends Layer<FlowNodesTransformLayerOption
     super.dispose();
   }
 
-  // onViewportChange() {
-  //   this.throttleUpdate()
-  // }
+  onViewportChange() {
+    if (getViewportCullingConfig(this.config).enabled) {
+      this.updateNodesBounds();
+    }
+  }
 
   // throttleUpdate = throttle(() => {
   //   this.renderCache.getFromCache().forEach((cache) => cache.updateBounds())
@@ -74,22 +91,25 @@ export class FlowNodesTransformLayer extends Layer<FlowNodesTransformLayerOption
       const { entity } = transform!;
       node.id = entity.id;
       let resizeDispose: Disposable | undefined;
+      let mounted = false;
       const append = () => {
-        if (resizeDispose) return;
+        if (mounted) return;
         // 监听 dom 节点的大小变化
         this.renderElement.appendChild(node);
+        mounted = true;
         if (!entity.getNodeMeta().autoResizeDisable) {
           resizeDispose = this.resizeObserver.observe(node, transform!);
         }
       };
       const dispose = () => {
-        if (!resizeDispose) return;
+        if (!mounted) return;
         // 脱离文档流，但是 react 组件会保留
         if (node.parentElement) {
           this.renderElement.removeChild(node);
         }
-        resizeDispose.dispose();
+        resizeDispose?.dispose();
         resizeDispose = undefined;
+        mounted = false;
       };
       append();
       return {
@@ -107,6 +127,16 @@ export class FlowNodesTransformLayer extends Layer<FlowNodesTransformLayerOption
       };
     }
   );
+
+  private shouldKeepTransformMounted(
+    transform: FlowNodeTransformData,
+    expandedViewport: ReturnType<typeof getExpandedViewport>
+  ): boolean {
+    if (shouldKeepNodeMounted(transform, this.document)) {
+      return true;
+    }
+    return isBoundsVisible(transform.bounds, expandedViewport);
+  }
 
   private isCoordEqual(a: number, b: number) {
     const browserCoordEpsilon = 0.05; // 浏览器处理坐标的精度误差: 两位小数四舍五入
@@ -126,7 +156,7 @@ export class FlowNodesTransformLayer extends Layer<FlowNodesTransformLayerOption
    */
   updateNodesBounds() {
     this.renderCache
-      .getMoreByItems(this.transformVisibles)
+      .getMoreByItems(this.visibleTransforms)
       .forEach((render) => render.updateBounds());
   }
 

--- a/packages/canvas-engine/renderer/src/utils/index.ts
+++ b/packages/canvas-engine/renderer/src/utils/index.ts
@@ -5,3 +5,4 @@
 
 export * from './scroll-limit';
 export * from './scroll-bar-events';
+export * from './viewport-culling';

--- a/packages/canvas-engine/renderer/src/utils/viewport-culling.ts
+++ b/packages/canvas-engine/renderer/src/utils/viewport-culling.ts
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Rectangle } from '@flowgram.ai/utils';
+import type { FlowDocument, FlowNodeTransformData } from '@flowgram.ai/document';
+import { PlaygroundConfigEntity } from '@flowgram.ai/core';
+
+export interface ViewportCullingConfig {
+  enabled: boolean;
+  lineEnabled: boolean;
+  overscan: number;
+}
+
+type ViewportCullingConfigData = {
+  viewportCulling?: boolean;
+  lineViewportCulling?: boolean;
+  viewportCullingOverscan?: number;
+};
+
+export function getViewportCullingConfig(config: PlaygroundConfigEntity): ViewportCullingConfig {
+  const cullingConfig = config.config as typeof config.config & ViewportCullingConfigData;
+  return {
+    enabled: cullingConfig.viewportCulling !== false,
+    lineEnabled: cullingConfig.lineViewportCulling !== false,
+    overscan: cullingConfig.viewportCullingOverscan ?? 300,
+  };
+}
+
+export function getExpandedViewport(config: PlaygroundConfigEntity, overscan?: number): Rectangle {
+  const viewport = config.getViewport();
+  const padding = overscan ?? getViewportCullingConfig(config).overscan;
+  return new Rectangle(
+    viewport.x - padding,
+    viewport.y - padding,
+    viewport.width + padding * 2,
+    viewport.height + padding * 2
+  );
+}
+
+export function isBoundsVisible(bounds: Rectangle, viewport: Rectangle): boolean {
+  if (!bounds || (bounds.width === 0 && bounds.height === 0)) {
+    return true;
+  }
+  return Rectangle.isViewportVisible(bounds, viewport);
+}
+
+export function shouldKeepNodeMounted(
+  transform: FlowNodeTransformData,
+  document: FlowDocument
+): boolean {
+  const { renderState } = transform;
+  return Boolean(
+    renderState.activated ||
+      renderState.hovered ||
+      renderState.dragging ||
+      transform.entity === document.renderState.getNodeHovered() ||
+      transform.entity === document.renderState.getDragStartEntity() ||
+      document.renderState.getDragEntities().includes(transform.entity)
+  );
+}

--- a/packages/client/free-layout-editor/src/preset/free-layout-preset.ts
+++ b/packages/client/free-layout-editor/src/preset/free-layout-preset.ts
@@ -5,7 +5,7 @@
 
 import { createSelectBoxPlugin } from '@flowgram.ai/select-box-plugin';
 import { createFreeStackPlugin, StackingContextManager } from '@flowgram.ai/free-stack-plugin';
-import { createFreeLinesPlugin } from '@flowgram.ai/free-lines-plugin';
+import { createFreeLinesPlugin, type FreeLinesPluginOptions } from '@flowgram.ai/free-lines-plugin';
 import {
   WorkflowCommands,
   WorkflowNodeEntity,
@@ -216,7 +216,13 @@ export function createFreeLayoutPreset(
       /**
        * 线条渲染插件
        */
-      createFreeLinesPlugin({}),
+      createFreeLinesPlugin({
+        viewportCulling: opts.playground?.lineViewportCulling,
+        viewportCullingOverscan: opts.playground?.viewportCullingOverscan,
+      } as FreeLinesPluginOptions & {
+        viewportCulling?: boolean;
+        viewportCullingOverscan?: number;
+      }),
       /**
        * 节点 hover 插件
        */

--- a/packages/client/free-layout-editor/src/preset/free-layout-props.ts
+++ b/packages/client/free-layout-editor/src/preset/free-layout-props.ts
@@ -59,6 +59,11 @@ export interface FreeLayoutPluginContext extends EditorPluginContext {
  * 自由布局配置
  */
 export interface FreeLayoutProps extends EditorProps<FreeLayoutPluginContext, WorkflowJSON> {
+  playground?: EditorProps<FreeLayoutPluginContext, WorkflowJSON>['playground'] & {
+    viewportCulling?: boolean;
+    viewportCullingOverscan?: number;
+    lineViewportCulling?: boolean;
+  };
   /**
    * SelectBox config
    * 选择框定义

--- a/packages/client/playground-react/src/preset/playground-react-props.ts
+++ b/packages/client/playground-react/src/preset/playground-react-props.ts
@@ -30,6 +30,9 @@ export interface PlaygroundReactProps<CTX extends PluginContext = PluginContext>
   playground?: PlaygroundLayerOptions & {
     autoFocus?: boolean; // 默认是否聚焦
     autoResize?: boolean; // 是否自动 resize 画布
+    viewportCulling?: boolean; // 是否开启视口裁剪
+    viewportCullingOverscan?: number; // 视口裁剪预渲染边距
+    lineViewportCulling?: boolean; // 是否开启线条视口裁剪
   };
   /**
    * 注册快捷键

--- a/packages/plugins/free-hover-plugin/src/hover-layer.tsx
+++ b/packages/plugins/free-hover-plugin/src/hover-layer.tsx
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-/* eslint-disable complexity */
 import { inject, injectable } from 'inversify';
 import { type IPoint } from '@flowgram.ai/utils';
 import { SelectorBoxConfigEntity } from '@flowgram.ai/renderer';
@@ -36,7 +35,6 @@ export interface HoverLayerOptions extends LayerOptions {
   canHovered?: (e: MouseEvent, service: WorkflowHoverService) => boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
 export namespace HoverLayerOptions {
   export const DEFAULT: HoverLayerOptions = {
     canHovered: () => true,
@@ -95,6 +93,15 @@ export class HoverLayer extends Layer<HoverLayerOptions> {
   @observeEntities(WorkflowLineEntity)
   protected readonly lines: WorkflowLineEntity[];
 
+  private pendingHover:
+    | {
+        mousePos: IPoint;
+        target?: HTMLElement;
+      }
+    | undefined;
+
+  private hoverFrame: number | undefined;
+
   /**
    * 是否正在调整线条
    * @protected
@@ -129,7 +136,7 @@ export class HoverLayer extends Layer<HoverLayerOptions> {
         }
         const mousePos = this.config.getPosFromMouseEvent(e);
         // 更新 hover 状态
-        this.updateHoveredState(mousePos, e?.target as HTMLElement);
+        this.scheduleHoveredStateUpdate(mousePos, e?.target as HTMLElement);
       }),
       this.selectionService.onSelectionChanged(() => this.autorun()),
       // 控制触控
@@ -192,16 +199,12 @@ export class HoverLayer extends Layer<HoverLayerOptions> {
    */
   updateHoveredState(mousePos: IPoint, target?: HTMLElement): void {
     const { hoverService } = this;
-    const nodeTransforms = this.nodeTransformsWithSort;
     const outputPortHovered = this.linesManager.getPortFromMousePos(mousePos, 'output');
     const inputPortHovered = this.linesManager.getPortFromMousePos(mousePos, 'input');
     // 在两个端口叠加情况，优先使用 outputPort
     const portHovered = outputPortHovered || inputPortHovered;
 
-    const lineDomNodes = this.playgroundNode.querySelectorAll(LINE_CLASS_NAME);
-    const checkTargetFromLine = [...lineDomNodes].some((lineDom) =>
-      lineDom.contains(target as HTMLElement)
-    );
+    const checkTargetFromLine = Boolean(target?.closest?.(LINE_CLASS_NAME));
     if (portHovered) {
       if (this.document.options.twoWayConnection) {
         hoverService.updateHoveredKey(portHovered.id);
@@ -225,15 +228,10 @@ export class HoverLayer extends Layer<HoverLayerOptions> {
       return;
     }
 
-    const nodeHovered = nodeTransforms.find((trans: FlowNodeTransformData) =>
-      trans.bounds.contains(mousePos.x, mousePos.y)
-    )?.entity as WorkflowNodeEntity;
+    const nodeHovered = this.linesManager.getNodeFromMousePos(mousePos);
 
     // 判断当前鼠标位置所在元素是否在节点内部
-    const nodeDomNodes = this.playgroundNode.querySelectorAll(NODE_CLASS_NAME);
-    const checkTargetFromNode = [...nodeDomNodes].some((nodeDom) =>
-      nodeDom.contains(target as HTMLElement)
-    );
+    const checkTargetFromNode = Boolean(target?.closest?.(NODE_CLASS_NAME));
 
     if (nodeHovered || checkTargetFromNode) {
       if (nodeHovered?.id) {
@@ -282,6 +280,22 @@ export class HoverLayer extends Layer<HoverLayerOptions> {
     // 鼠标优先交互模式，如果是 hover，需要将鼠标的小手去掉，还原鼠标原有样式
     this.configEntity.updateCursor('default');
     this.hoverService.updateHoveredKey(key);
+  }
+
+  private scheduleHoveredStateUpdate(mousePos: IPoint, target?: HTMLElement): void {
+    this.pendingHover = { mousePos, target };
+    if (this.hoverFrame !== undefined) {
+      return;
+    }
+    this.hoverFrame = requestAnimationFrame(() => {
+      this.hoverFrame = undefined;
+      const pending = this.pendingHover;
+      this.pendingHover = undefined;
+      if (!pending) {
+        return;
+      }
+      this.updateHoveredState(pending.mousePos, pending.target);
+    });
   }
 
   /**

--- a/packages/plugins/free-lines-plugin/src/components/workflow-port-render/index.tsx
+++ b/packages/plugins/free-lines-plugin/src/components/workflow-port-render/index.tsx
@@ -35,7 +35,6 @@ export interface WorkflowPortRenderProps {
 }
 
 export const WorkflowPortRender: React.FC<WorkflowPortRenderProps> =
-  // eslint-disable-next-line react/display-name
   React.memo<WorkflowPortRenderProps>((props: WorkflowPortRenderProps) => {
     const hoverService = useService<WorkflowHoverService>(WorkflowHoverService);
     const linesManager = useService<WorkflowLinesManager>(WorkflowLinesManager);
@@ -67,7 +66,8 @@ export const WorkflowPortRender: React.FC<WorkflowPortRenderProps> =
         updatePosY(Math.round(newPos.y));
       });
       const dispose2 = hoverService.onHoveredChange((id) => {
-        setHovered(hoverService.isHovered(entity.id));
+        const nextHovered = id === entity.id;
+        setHovered((prev) => (prev === nextHovered ? prev : nextHovered));
       });
       const dispose3 = entity.onErrorChanged(() => {
         setHasError(entity.hasError);
@@ -75,7 +75,8 @@ export const WorkflowPortRender: React.FC<WorkflowPortRenderProps> =
       const dispose4 = linesManager.onAvailableLinesChange(() => {
         setTimeout(() => {
           if (linesManager.disposed || entity.disposed) return;
-          setLinked(Boolean(entity.lines.length));
+          const nextLinked = Boolean(entity.lines.length);
+          setLinked((prev) => (prev === nextLinked ? prev : nextLinked));
         }, 0);
       });
       return () => {

--- a/packages/plugins/free-lines-plugin/src/create-free-lines-plugin.ts
+++ b/packages/plugins/free-lines-plugin/src/create-free-lines-plugin.ts
@@ -19,6 +19,8 @@ export const createFreeLinesPlugin = definePluginCreator({
   onInit: (ctx: PluginContext, opts: FreeLinesPluginOptions) => {
     ctx.playground.registerLayer(WorkflowLinesLayer, {
       ...opts,
+      viewportCulling: opts.viewportCulling,
+      viewportCullingOverscan: opts.viewportCullingOverscan,
     });
   },
   onReady: (ctx: PluginContext, opts: FreeLinesPluginOptions) => {

--- a/packages/plugins/free-lines-plugin/src/layer/workflow-lines-layer.tsx
+++ b/packages/plugins/free-lines-plugin/src/layer/workflow-lines-layer.tsx
@@ -6,8 +6,9 @@
 import ReactDOM from 'react-dom';
 import React, { ReactNode, useLayoutEffect, useState } from 'react';
 
+import { throttle } from 'lodash-es';
 import { inject, injectable } from 'inversify';
-import { domUtils } from '@flowgram.ai/utils';
+import { domUtils, Rectangle } from '@flowgram.ai/utils';
 import { FlowRendererRegistry } from '@flowgram.ai/renderer';
 import { StackingContextManager } from '@flowgram.ai/free-stack-plugin';
 import {
@@ -24,6 +25,8 @@ import { Layer, observeEntities, observeEntityDatas, TransformData } from '@flow
 
 import { LineRenderProps, LinesLayerOptions } from '../type';
 import { WorkflowLineRender } from '../components';
+
+const DEFAULT_VIEWPORT_CULLING_OVERSCAN = 300;
 
 @injectable()
 export class WorkflowLinesLayer extends Layer<LinesLayerOptions> {
@@ -57,6 +60,8 @@ export class WorkflowLinesLayer extends Layer<LinesLayerOptions> {
     }
   > = new Map();
 
+  private disposeBoundLineIds = new Set<string>();
+
   private _version = 0;
 
   /**
@@ -67,6 +72,12 @@ export class WorkflowLinesLayer extends Layer<LinesLayerOptions> {
   public onZoom(scale: number): void {
     this.node.style.transform = `scale(${scale})`;
   }
+
+  public onViewportChange: ReturnType<typeof throttle> = throttle(() => {
+    if (this.isLineViewportCullingEnabled()) {
+      this.render();
+    }
+  }, 80);
 
   public onReady() {
     this.pipelineNode.appendChild(this.node);
@@ -83,17 +94,19 @@ export class WorkflowLinesLayer extends Layer<LinesLayerOptions> {
 
   public dispose() {
     this.mountedLines.clear();
+    this.disposeBoundLineIds.clear();
   }
 
   public render(): JSX.Element {
     const [, forceUpdate] = useState({});
+    const viewportSignature = this.getViewportSignature();
 
     useLayoutEffect(() => {
       const updateLines = (): void => {
         let needsUpdate = false;
 
-        // 批量处理所有线条的更新
-        this.lines.forEach((line) => {
+        // 只更新当前需要渲染 / 保活的线条，避免大图下每帧遍历并计算所有 path。
+        this.getRenderableLines().forEach((line) => {
           const renderData = line.getData(WorkflowLineRenderData);
           const oldVersion = renderData.renderVersion;
           renderData.update();
@@ -111,9 +124,12 @@ export class WorkflowLinesLayer extends Layer<LinesLayerOptions> {
 
       const rafId = requestAnimationFrame(updateLines);
       return () => cancelAnimationFrame(rafId);
-    }, [this.lines]); // 依赖项包含 lines
+    }, [this.lines, viewportSignature]); // 依赖项包含 lines 和视口 bucket
 
-    const lines = this.lines.map((line) => this.renderLine(line));
+    const renderableLines = this.getRenderableLines();
+    const renderableLineIds = new Set(renderableLines.map((line) => line.id));
+    this.unmountHiddenLines(renderableLineIds);
+    const lines = renderableLines.map((line) => this.renderLine(line));
     return <>{lines}</>;
   }
 
@@ -179,15 +195,114 @@ export class WorkflowLinesLayer extends Layer<LinesLayerOptions> {
     if (!isCached) {
       // 如果缓存不存在，则将 line 挂载到 renderElement 上
       this.renderElement.appendChild(line.node);
-      line.onDispose(() => {
-        this.mountedLines.delete(line.id);
-        line.node.remove();
-      });
+      this.bindLineDispose(line);
     }
     // 刷新缓存
     const portal = ReactDOM.createPortal(this.lineComponent(lineProps), line.node);
     this.mountedLines.set(line.id, { line, portal, version: lineProps.version });
     return portal;
+  }
+
+  private getRenderableLines(): WorkflowLineEntity[] {
+    if (!this.isLineViewportCullingEnabled()) {
+      return this.lines;
+    }
+    const viewport = this.getExpandedViewport();
+    return this.lines.filter((line) => this.shouldRenderLine(line, viewport));
+  }
+
+  private getViewportSignature(): string {
+    const viewport = this.config.getViewport();
+    const bucketSize = Math.max(1, this.getViewportCullingOverscan() / 2);
+    return [
+      Math.floor(viewport.x / bucketSize),
+      Math.floor(viewport.y / bucketSize),
+      Math.round(viewport.width),
+      Math.round(viewport.height),
+      Math.round(this.config.finalScale * 1000),
+    ].join('|');
+  }
+
+  private shouldRenderLine(line: WorkflowLineEntity, viewport: Rectangle): boolean {
+    if (
+      line.isDrawing ||
+      line.hasError ||
+      line.flowing ||
+      this.selectService.isSelected(line.id) ||
+      this.hoverService.isHovered(line.id)
+    ) {
+      return true;
+    }
+    const bounds = this.getLineCoarseBounds(line);
+    return bounds ? this.isBoundsVisible(bounds, viewport) : true;
+  }
+
+  private getLineCoarseBounds(line: WorkflowLineEntity): Rectangle | undefined {
+    const from = line.drawingFrom || line.fromPort?.point;
+    const to = line.drawingTo || line.toPort?.point;
+    if (!from || !to) {
+      return line.bounds;
+    }
+    const left = Math.min(from.x, to.x);
+    const top = Math.min(from.y, to.y);
+    const right = Math.max(from.x, to.x);
+    const bottom = Math.max(from.y, to.y);
+    return new Rectangle(left, top, right - left, bottom - top).pad(40);
+  }
+
+  private unmountHiddenLines(renderableLineIds: Set<string>): void {
+    this.mountedLines.forEach(({ line }, id) => {
+      if (renderableLineIds.has(id)) {
+        return;
+      }
+      line.node.remove();
+      this.mountedLines.delete(id);
+    });
+  }
+
+  private bindLineDispose(line: WorkflowLineEntity): void {
+    if (this.disposeBoundLineIds.has(line.id)) {
+      return;
+    }
+    this.disposeBoundLineIds.add(line.id);
+    line.onDispose(() => {
+      this.disposeBoundLineIds.delete(line.id);
+      this.mountedLines.delete(line.id);
+      line.node.remove();
+    });
+  }
+
+  private isLineViewportCullingEnabled(): boolean {
+    return (
+      this.options.viewportCulling !== false &&
+      (this.config.config as { lineViewportCulling?: boolean }).lineViewportCulling !== false
+    );
+  }
+
+  private getViewportCullingOverscan(): number {
+    return (
+      this.options.viewportCullingOverscan ??
+      (this.config.config as { viewportCullingOverscan?: number }).viewportCullingOverscan ??
+      DEFAULT_VIEWPORT_CULLING_OVERSCAN
+    );
+  }
+
+  private getExpandedViewport(): Rectangle {
+    const viewport = this.config.getViewport();
+    const padding = this.getViewportCullingOverscan();
+    return new Rectangle(
+      viewport.x - padding,
+      viewport.y - padding,
+      viewport.width + padding * 2,
+      viewport.height + padding * 2
+    );
+  }
+
+  private isBoundsVisible(bounds: Rectangle, viewport: Rectangle): boolean {
+    if (!bounds || (bounds.width === 0 && bounds.height === 0)) {
+      return true;
+    }
+    return Rectangle.isViewportVisible(bounds, viewport);
   }
 
   private get renderElement(): HTMLElement {

--- a/packages/plugins/free-lines-plugin/src/type.ts
+++ b/packages/plugins/free-lines-plugin/src/type.ts
@@ -27,6 +27,8 @@ export interface LineRenderProps {
 
 export interface LinesLayerOptions {
   renderInsideLine?: FC<LineRenderProps>;
+  viewportCulling?: boolean;
+  viewportCullingOverscan?: number;
 }
 
 export interface FreeLinesPluginOptions extends LinesLayerOptions {

--- a/packages/plugins/free-stack-plugin/src/manager.ts
+++ b/packages/plugins/free-stack-plugin/src/manager.ts
@@ -141,7 +141,12 @@ export class StackingContextManager {
 
   private onHover(): Disposable {
     return this.hoverService.onHoveredChange(() => {
-      this.compute();
+      // Hover changes at mousemove frequency. Recomputing stacking for every node / line
+      // on each hover frame is a long-tail cost on large canvases; selection and entity
+      // changes still trigger full recompute where persistent z-order matters.
+      if (this.nodes.length < 128) {
+        this.compute();
+      }
     });
   }
 


### PR DESCRIPTION
Panning the pipeline node used left/top, which are layout-inducing and force a full-subtree reflow on every pan frame (dominates cost with many nodes). Switch to transform: translate3d (compositor-only, no layout/paint).

All coordinate math relies on config.scrollX/scrollY (not DOM offsets), so the visual result is identical. Consumers that read pipelineNode offsetLeft/offsetTop/style.left (fixed-layout drag, context menu, debug origin line) are updated to derive the offset from scrollX/scrollY.


Change-Id: I5eb44fb09e55b4a2a5fa8e1b83141b88033c5124