### PR TITLE
fix(free-layout): refresh lines after JSON layout

### DIFF
--- a/packages/canvas-engine/free-layout-core/__tests__/workflow-document.test.ts
+++ b/packages/canvas-engine/free-layout-core/__tests__/workflow-document.test.ts
@@ -40,6 +40,34 @@ describe('workflow-document', () => {
     expect(document.toJSON()).toEqual(baseJSON);
   });
 
+  it('refreshes lines after the initial fromJSON layout frame', () => {
+    const callbacks: FrameRequestCallback[] = [];
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      });
+    const linesManager = container.get(WorkflowLinesManager);
+    const forceUpdateSpy = vi.spyOn(linesManager, 'forceUpdate');
+
+    document.fromJSON(baseJSON);
+
+    expect(requestAnimationFrameSpy).toHaveBeenCalledOnce();
+    expect(forceUpdateSpy).not.toHaveBeenCalled();
+
+    callbacks[0](0);
+    expect(forceUpdateSpy).toHaveBeenCalledOnce();
+  });
+
+  it('does not schedule a line refresh when rendering is disabled', () => {
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame');
+
+    document.fromJSON(baseJSON, false);
+
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+  });
+
   it('nested fromJSON and toJSON', () => {
     document.fromJSON(nestJSON);
     expect(document.toJSON()).toEqual(nestJSON);

--- a/packages/canvas-engine/free-layout-core/__tests__/workflow-document.test.ts
+++ b/packages/canvas-engine/free-layout-core/__tests__/workflow-document.test.ts
@@ -27,6 +27,10 @@ beforeEach(() => {
   document = container.get(WorkflowDocument);
 });
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('workflow-document', () => {
   it('load', async () => {
     const fn = vi.fn();
@@ -66,6 +70,37 @@ describe('workflow-document', () => {
     document.fromJSON(baseJSON, false);
 
     expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps only the latest line refresh across repeated fromJSON calls', () => {
+    const callbacks: FrameRequestCallback[] = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    });
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame');
+    const linesManager = container.get(WorkflowLinesManager);
+    const forceUpdateSpy = vi.spyOn(linesManager, 'forceUpdate');
+
+    document.fromJSON(baseJSON);
+    document.fromJSON(baseJSON);
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledOnce();
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1);
+
+    callbacks[1](0);
+    expect(forceUpdateSpy).toHaveBeenCalledOnce();
+  });
+
+  it('cancels a pending line refresh when rendering is disabled', () => {
+    vi.spyOn(window, 'requestAnimationFrame').mockReturnValue(1);
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame');
+
+    document.fromJSON(baseJSON);
+    document.fromJSON(baseJSON, false);
+
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledOnce();
+    expect(cancelAnimationFrameSpy).toHaveBeenCalledWith(1);
   });
 
   it('nested fromJSON and toJSON', () => {

--- a/packages/canvas-engine/free-layout-core/src/workflow-document.ts
+++ b/packages/canvas-engine/free-layout-core/src/workflow-document.ts
@@ -157,6 +157,13 @@ export class WorkflowDocument extends FlowDocument {
     // 批量触发画布更新
     if (fireRender) {
       this.fireRender();
+      // Ports may not have their final DOM measurements during the initial
+      // render. Re-render lines on the next frame after layout has settled.
+      window.requestAnimationFrame(() => {
+        if (!this.disposed) {
+          this.linesManager.forceUpdate();
+        }
+      });
     }
   }
 

--- a/packages/canvas-engine/free-layout-core/src/workflow-document.ts
+++ b/packages/canvas-engine/free-layout-core/src/workflow-document.ts
@@ -59,6 +59,8 @@ export class WorkflowDocument extends FlowDocument {
 
   protected readonly onLoadedEmitter = new Emitter<void>();
 
+  private lineRenderFrame: number | undefined;
+
   readonly onContentChange = this._onContentChangeEmitter.event;
 
   private _onReloadEmitter = new Emitter<WorkflowDocument>();
@@ -142,6 +144,7 @@ export class WorkflowDocument extends FlowDocument {
    */
   fromJSON(json: Partial<WorkflowJSON>, fireRender = true): void {
     if (this.disposed) return;
+    this.cancelLineRenderFrame();
     const workflowJSON: WorkflowJSON = {
       nodes: json.nodes ?? [],
       edges: json.edges ?? [],
@@ -159,7 +162,8 @@ export class WorkflowDocument extends FlowDocument {
       this.fireRender();
       // Ports may not have their final DOM measurements during the initial
       // render. Re-render lines on the next frame after layout has settled.
-      window.requestAnimationFrame(() => {
+      this.lineRenderFrame = window.requestAnimationFrame(() => {
+        this.lineRenderFrame = undefined;
         if (!this.disposed) {
           this.linesManager.forceUpdate();
         }
@@ -710,8 +714,16 @@ export class WorkflowDocument extends FlowDocument {
   }
 
   dispose() {
+    this.cancelLineRenderFrame();
     super.dispose();
     this._onReloadEmitter.dispose();
+  }
+
+  private cancelLineRenderFrame(): void {
+    if (this.lineRenderFrame !== undefined) {
+      window.cancelAnimationFrame(this.lineRenderFrame);
+      this.lineRenderFrame = undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Refresh free-layout edges after `fromJSON()` has rendered and browser layout has settled.

Ports may not have final DOM measurements during the initial render. Updating lines immediately can therefore leave edges at stale positions until another interaction triggers a refresh.

This change schedules a line refresh on the next animation frame and manages that deferred callback safely:

- keeps only the latest refresh across repeated `fromJSON()` calls
- cancels a pending refresh when a later call uses `fireRender=false`
- cancels pending work when the document is disposed
- does not change the existing synchronous render path

## Validation

- `vitest run` in `free-layout-core` — 11 files, 88 tests passed
- ESLint on the changed implementation and tests
- `tsc --noEmit`
- `git diff --check`

Regression tests cover deferred refresh, default layout configuration, disabled rendering, repeated loads, and cancellation of stale callbacks.

## AI assistance

This change was developed with AI assistance. I reviewed the animation-frame lifecycle and ran the package-level checks above.
