### PR TITLE
chore(ci): upgrade actions/checkout and actions/setup-node to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Config Git User
@@ -21,7 +21,7 @@ jobs:
         run: |
           echo "Listing files in the root directory:"
           ls -alh
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       # - name: Verify Change Logs

--- a/.github/workflows/common-pr-checks.yml
+++ b/.github/workflows/common-pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     name: PR Common Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -17,7 +17,7 @@ jobs:
           git config --local user.name "tecvan"
           git config --local user.email "fanwenjie.fe@bytedance.com"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
Fixes #1158

### Description
Upgrade `actions/checkout` and `actions/setup-node` from `v3` to `v4` across CI workflows (`ci.yml` and `common-pr-checks.yml`).

### Motivation
GitHub Actions official runners have deprecated Node 16-based actions (`@v3`). Moving to `@v4` ensures full Node 20 runtime compatibility and keeps our CI pipeline clean and up to date.

### Changes
- Upgrade `actions/checkout@v3` -> `actions/checkout@v4` in `ci.yml` & `common-pr-checks.yml`
- Upgrade `actions/setup-node@v3` -> `actions/setup-node@v4` in `ci.yml` & `common-pr-checks.yml`

### Verification
- Verified workflow YAML syntax and step compatibility against GitHub Actions v4 schema.