### PR TITLE
fix(export): preserve lines SVG viewBox on fixed-layout export

### DIFF
--- a/packages/plugins/export-plugin/src/export-image-service/service.ts
+++ b/packages/plugins/export-plugin/src/export-image-service/service.ts
@@ -218,7 +218,7 @@ export class FlowExportImageService implements IFlowExportImageService {
     cloned.style.top = `${PADDING_Y}px`;
     cloned.style.transform = 'none';
     cloned.style.backgroundColor = 'transparent';
-    cloned.querySelector('.flow-lines-container')!.setAttribute('viewBox', `0 0 1000 1000`);
+    // Keep the live canvas viewBox (depends on zoom) so exported lines stay aligned.
   }
 
   // 处理画布


### PR DESCRIPTION
## Summary

Fixed-layout image export cloned the live lines layer but then overwrote the SVG `viewBox` with a hardcoded `0 0 1000 1000`.

On canvas, `FlowLinesLayer` sets `viewBox` from the current zoom (`1000 / finalScale`). Forcing `1000 x 1000` during export mis-scales connection paths relative to nodes, which shows up as crooked lines in exported PNG/SVG/JPEG.

This change keeps the cloned viewBox from the live canvas.

Fixes #1146

## Testing plan

- [ ] Open a fixed-layout workflow with several connected nodes
- [ ] Export PNG/SVG at default zoom and after zoom in/out
- [ ] Verify connection lines stay aligned with node ports in the export
- [ ] Sanity-check free-layout export (unchanged code path)
