### PR TITLE
fix(runtime): use raw text body field

### DIFF
--- a/packages/runtime/js-core/src/domain/__tests__/schemas/http.test.ts
+++ b/packages/runtime/js-core/src/domain/__tests__/schemas/http.test.ts
@@ -177,6 +177,47 @@ describe('WorkflowRuntime http schema', () => {
     expect(report.reports.end_0.status).toBe(WorkflowStatus.Succeeded);
   });
 
+  it('should send a raw-text request body', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: new Headers(),
+      text: async () => 'OK',
+    });
+
+    const schema = structuredClone(TestSchemas.httpSchema);
+    const httpNode = schema.nodes.find((node) => node.id === 'http_0');
+    if (!httpNode) {
+      throw new Error('HTTP test node not found');
+    }
+    httpNode.data.body = {
+      bodyType: 'raw-text',
+      rawText: {
+        type: 'template',
+        content: 'request to {{start_0.path}}',
+      },
+    };
+
+    const engine = container.get<IEngine>(IEngine);
+    const { processing } = engine.invoke({
+      schema,
+      inputs: {
+        host: 'api.example.com',
+        path: '/raw',
+      },
+    });
+
+    await processing;
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/raw',
+      expect.objectContaining({
+        body: 'request to /raw',
+      })
+    );
+  });
+
   it('should handle HTTP request failure', async () => {
     // Mock HTTP error response
     mockFetch.mockResolvedValueOnce({

--- a/packages/runtime/js-core/src/nodes/http/index.ts
+++ b/packages/runtime/js-core/src/nodes/http/index.ts
@@ -159,16 +159,16 @@ export class HTTPExecutor implements INodeExecutor {
       };
     }
     if (bodyType === HTTPBodyType.RawText) {
-      if (!httpNode.data.body.json) {
-        throw new Error('HTTP json body is required');
+      if (!httpNode.data.body.rawText) {
+        throw new Error('HTTP raw text body is required');
       }
-      const jsonVariable = context.runtime.state.parseTemplate(httpNode.data.body.json);
-      if (!jsonVariable) {
-        throw new Error('HTTP json body is required');
+      const rawTextVariable = context.runtime.state.parseTemplate(httpNode.data.body.rawText);
+      if (!rawTextVariable) {
+        throw new Error('HTTP raw text body is required');
       }
       return {
         bodyType,
-        body: jsonVariable.value,
+        body: rawTextVariable.value,
       };
     }
     if (bodyType === HTTPBodyType.Binary) {


### PR DESCRIPTION
## Summary

- read the HTTP node's `rawText` field for raw-text request bodies
- return a body-type-specific validation error when the value is missing
- add a workflow-level regression test that verifies the rendered raw-text body passed to `fetch`

Fixes #1165

## Validation

- `rushx test` in `packages/runtime/js-core` (32 files, 299 tests passed)
- `rushx ts-check` in `packages/runtime/js-core`
- `rushx build` in `packages/runtime/js-core`
- `rushx lint` in `packages/runtime/js-core` (exit 0; existing Windows CRLF warnings remain)