### PR TITLE
fix(runtime): reset timeout for HTTP retries

### DIFF
--- a/packages/runtime/js-core/src/domain/__tests__/schemas/http.test.ts
+++ b/packages/runtime/js-core/src/domain/__tests__/schemas/http.test.ts
@@ -215,6 +215,56 @@ describe('WorkflowRuntime http schema', () => {
     );
   });
 
+  it('should use a fresh timeout signal for each retry', async () => {
+    mockFetch
+      .mockImplementationOnce((_url: string, options: RequestInit) => {
+        const signal = options.signal as AbortSignal;
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+        });
+      })
+      .mockImplementationOnce((_url: string, options: RequestInit) => {
+        const signal = options.signal as AbortSignal;
+        if (signal.aborted) {
+          return Promise.reject(signal.reason);
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          headers: new Headers(),
+          text: async () => 'OK',
+        });
+      });
+
+    const schema = structuredClone(TestSchemas.httpSchema);
+    const httpNode = schema.nodes.find((node) => node.id === 'http_0');
+    if (!httpNode) {
+      throw new Error('HTTP test node not found');
+    }
+    httpNode.data.timeout = {
+      timeout: 10,
+      retryTimes: 1,
+    };
+
+    const engine = container.get<IEngine>(IEngine);
+    const { processing } = engine.invoke({
+      schema,
+      inputs: {
+        host: 'api.example.com',
+        path: '/retry',
+      },
+    });
+
+    await expect(processing).resolves.toMatchObject({ code: 200 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const firstSignal = mockFetch.mock.calls[0][1].signal;
+    const secondSignal = mockFetch.mock.calls[1][1].signal;
+    expect(firstSignal).not.toBe(secondSignal);
+    expect(secondSignal.aborted).toBe(false);
+  });
+
   it('should handle network error', async () => {
     // Mock network error
     mockFetch.mockRejectedValueOnce(new Error('Network error'));

--- a/packages/runtime/js-core/src/nodes/http/index.ts
+++ b/packages/runtime/js-core/src/nodes/http/index.ts
@@ -58,7 +58,6 @@ export class HTTPExecutor implements INodeExecutor {
     const requestOptions: RequestInit = {
       method,
       headers: this.prepareHeaders(headers, bodyType),
-      signal: AbortSignal.timeout(timeout),
     };
 
     // Add body if method supports it
@@ -70,7 +69,10 @@ export class HTTPExecutor implements INodeExecutor {
     let lastError: Error | null = null;
     for (let attempt = 0; attempt <= retryTimes; attempt++) {
       try {
-        const response = await fetch(urlWithParams, requestOptions);
+        const response = await fetch(urlWithParams, {
+          ...requestOptions,
+          signal: AbortSignal.timeout(timeout),
+        });
         return response;
       } catch (error) {
         lastError = error as Error;


### PR DESCRIPTION
## Summary

- create a new timeout signal for every HTTP retry attempt
- preserve the existing request options and retry/backoff behavior
- add a regression test that times out the first attempt and verifies the retry receives a distinct, active signal

Fixes #1166

## Validation

- `rush-pnpm exec vitest run src/domain/__tests__/schemas/http.test.ts` (5 tests passed)
- `rushx test` in `packages/runtime/js-core` (32 files, 299 tests passed)
- `rushx ts-check` in `packages/runtime/js-core`
- `rushx build` in `packages/runtime/js-core`
- targeted ESLint on the two changed files (exit 0; existing Windows CRLF warnings remain)