### PR TITLE
docs(cli): correct material name examples

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -29,7 +29,7 @@ program
   .description('Sync materials to the project')
   .argument(
     '[string]',
-    'Material name or names\nExample 1: components/variable-selector \nExample2: components/variable-selector,effect/provideJsonSchemaOutputs'
+    'Material name or names\nExample 1: components/variable-selector \nExample2: components/variable-selector,effects/provide-json-schema-outputs'
   )
   .option('--refresh-project-imports', 'Refresh project imports to copied materials', false)
   .option('--target-material-root-dir <string>', 'Target directory to copy materials')

--- a/apps/docs/src/en/materials/cli.mdx
+++ b/apps/docs/src/en/materials/cli.mdx
@@ -22,7 +22,7 @@ npx @flowgram.ai/cli@latest materials
 npx @flowgram.ai/cli@latest materials components/json-schema-editor
 
 # Specify multiple materials (comma-separated)
-npx @flowgram.ai/cli@latest materials components/variable-selector,effect/provideJsonSchemaOutputs
+npx @flowgram.ai/cli@latest materials components/variable-selector,effects/provide-json-schema-outputs
 
 # Select multiple materials (interactive multi-select)
 npx @flowgram.ai/cli@latest materials --select-multiple
@@ -39,7 +39,7 @@ After running, the CLI will prompt you to select materials to add to your projec
 🚀 The following materials will be added to your project
 📦 components/json-schema-editor
 📦 components/variable-selector
-📦 effect/provideJsonSchemaOutputs
+📦 effects/provide-json-schema-outputs
 
 ✅ These npm dependencies is added to your package.json
 - @semi-design/icons

--- a/apps/docs/src/zh/materials/cli.mdx
+++ b/apps/docs/src/zh/materials/cli.mdx
@@ -22,7 +22,7 @@ npx @flowgram.ai/cli@latest materials
 npx @flowgram.ai/cli@latest materials components/json-schema-editor
 
 # 指定多个物料（逗号分隔）
-npx @flowgram.ai/cli@latest materials components/variable-selector,effect/provideJsonSchemaOutputs
+npx @flowgram.ai/cli@latest materials components/variable-selector,effects/provide-json-schema-outputs
 
 # 选择多个物料（交互式多选）
 npx @flowgram.ai/cli@latest materials --select-multiple
@@ -39,7 +39,7 @@ npx @flowgram.ai/cli@latest materials --select-multiple
 🚀 The following materials will be added to your project
 📦 components/json-schema-editor
 📦 components/variable-selector
-📦 effect/provideJsonSchemaOutputs
+📦 effects/provide-json-schema-outputs
 
 ✅ These npm dependencies is added to your package.json
 - @semi-design/icons


### PR DESCRIPTION
## Summary

- use the material's exact `effects/provide-json-schema-outputs` full name in CLI help
- update the direct-selection command and sample output in both English and Chinese guides
- keep the localized sources and generated site content aligned

Fixes #1167

## Validation

- confirmed `effect/provideJsonSchemaOutputs` no longer appears in the changed sources or built documentation
- `rushx build` in `apps/cli`
- `rushx build` in `apps/docs` (Rspress 2.0.0-rc.6)
- targeted ESLint on `apps/cli/src/index.ts` (exit 0; existing Windows CRLF warnings remain)