### PR TITLE
fix(cli): scaffold projects without partial mutations

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,6 +20,7 @@
     "lint:fix": "eslint ./src --fix"
   },
   "dependencies": {
+    "@flowgram.ai/create-app": "workspace:*",
     "fs-extra": "^9.1.0",
     "commander": "^11.0.0",
     "chalk": "^5.3.0",

--- a/apps/cli/src/create-app/index.ts
+++ b/apps/cli/src/create-app/index.ts
@@ -4,56 +4,17 @@
  */
 
 import path from 'path';
-import https from 'https';
 import { execSync } from 'child_process';
 
-import * as tar from 'tar';
 import inquirer from 'inquirer';
-import fs from 'fs-extra';
 import chalk from 'chalk';
-
-const updateFlowGramVersions = (dependencies: any[], latestVersion: string) => {
-  for (const packageName in dependencies) {
-    if (packageName.startsWith('@flowgram.ai')) {
-      dependencies[packageName] = latestVersion;
-    }
-  }
-};
-
-// 使用 https 下载文件
-function downloadFile(url: string, dest: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const file = fs.createWriteStream(dest);
-
-    https
-      .get(url, (response) => {
-        if (response.statusCode !== 200) {
-          reject(new Error(`Download failed: ${response.statusCode}`));
-          return;
-        }
-
-        response.pipe(file);
-
-        file.on('finish', () => {
-          file.close();
-          resolve();
-        });
-      })
-      .on('error', (err) => {
-        fs.unlink(dest, () => reject(err));
-      });
-
-    file.on('error', (err) => {
-      fs.unlink(dest, () => reject(err));
-    });
-  });
-}
+import {
+  assertProjectDestinationAvailable,
+  scaffoldProject,
+} from '@flowgram.ai/create-app/scaffold';
 
 export const createApp = async (projectName?: string) => {
   console.log(chalk.green('Welcome to @flowgram.ai/create-app CLI!'));
-  const latest = execSync('npm view @flowgram.ai/demo-fixed-layout version --tag=latest latest')
-    .toString()
-    .trim();
 
   let folderName = '';
 
@@ -97,66 +58,31 @@ export const createApp = async (projectName?: string) => {
 
   try {
     const targetDir = path.join(process.cwd());
+    await assertProjectDestinationAvailable(targetDir, folderName);
 
-    // 下载 npm 包的 tarball
-    const downloadPackage = async () => {
-      try {
-        const url = `https://registry.npmjs.org/@flowgram.ai/${folderName}/-/${folderName}-${latest}.tgz`;
-        const tempTarballPath = path.join(process.cwd(), `${folderName}.tgz`);
-
-        console.log(chalk.blue(`Downloading ${url} ...`));
-        await downloadFile(url, tempTarballPath);
-
-        fs.ensureDirSync(targetDir);
-
-        await tar.x({
-          file: tempTarballPath,
-          C: targetDir,
-        });
-
-        fs.renameSync(path.join(targetDir, 'package'), path.join(targetDir, folderName));
-
-        fs.unlinkSync(tempTarballPath);
-        return true;
-      } catch (error) {
-        console.error(`Error downloading or extracting package`);
-        console.error(error);
-        return false;
-      }
-    };
-
-    const res = await downloadPackage();
-
-    // 替换 package.json 内部的 @flowgram.ai 包版本为 latest
-    const pkgJsonPath = path.join(targetDir, folderName, 'package.json');
-    const data = fs.readFileSync(pkgJsonPath, 'utf-8');
-
+    const latest = execSync('npm view @flowgram.ai/demo-fixed-layout version --tag=latest latest')
+      .toString()
+      .trim();
     const packageLatestVersion = execSync('npm view @flowgram.ai/core version --tag=latest latest')
       .toString()
       .trim();
+    const url = `https://registry.npmjs.org/@flowgram.ai/${folderName}/-/${folderName}-${latest}.tgz`;
 
-    const jsonData = JSON.parse(data);
-    if (jsonData.dependencies) {
-      updateFlowGramVersions(jsonData.dependencies, packageLatestVersion);
-    }
+    await scaffoldProject({
+      targetDir,
+      folderName,
+      templateUrl: url,
+      flowgramVersion: packageLatestVersion,
+      onDownload: (downloadUrl) => console.log(chalk.blue(`Downloading ${downloadUrl} ...`)),
+    });
 
-    if (jsonData.devDependencies) {
-      updateFlowGramVersions(jsonData.devDependencies, packageLatestVersion);
-    }
-
-    fs.writeFileSync(pkgJsonPath, JSON.stringify(jsonData, null, 2), 'utf-8');
-
-    if (res) {
-      console.log(chalk.green(`${folderName} Demo project created successfully!`));
-      console.log(chalk.yellow('Run the following commands to start:'));
-      console.log(chalk.cyan(`  cd ${folderName}`));
-      console.log(chalk.cyan('  npm install'));
-      console.log(chalk.cyan('  npm start'));
-    } else {
-      console.log(chalk.red('Download failed'));
-    }
+    console.log(chalk.green(`${folderName} Demo project created successfully!`));
+    console.log(chalk.yellow('Run the following commands to start:'));
+    console.log(chalk.cyan(`  cd ${folderName}`));
+    console.log(chalk.cyan('  npm install'));
+    console.log(chalk.cyan('  npm start'));
   } catch (error) {
-    console.error('Error downloading repo:', error);
+    console.error('Error creating project:', error);
     return;
   }
 };

--- a/apps/create-app/package.json
+++ b/apps/create-app/package.json
@@ -7,16 +7,26 @@
     "create-app": "./bin/index.js"
   },
   "type": "module",
+  "exports": {
+    "./scaffold": {
+      "types": "./dist/scaffold.d.ts",
+      "import": "./dist/scaffold.js",
+      "require": "./dist/scaffold.cjs"
+    }
+  },
   "files": [
     "bin",
     "src",
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --out-dir dist",
+    "build": "tsup src/index.ts src/scaffold.ts --format esm,cjs --dts --out-dir dist",
     "start": "node bin/index.js",
-    "lint": "eslint ./src --cache",
-    "lint:fix": "eslint ./src --fix"
+    "lint": "eslint ./src ./tests --cache",
+    "lint:fix": "eslint ./src ./tests --fix",
+    "test": "vitest run",
+    "test:cov": "vitest run --coverage",
+    "ts-check": "tsc --noEmit"
   },
   "dependencies": {
     "fs-extra": "^9.1.0",
@@ -33,7 +43,9 @@
     "tsup": "^8.0.1",
     "eslint": "^9.0.0",
     "@typescript-eslint/parser": "^8.0.0",
-    "typescript": "^5.8.3"
+    "@vitest/coverage-v8": "^3.2.4",
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   },
   "publishConfig": {
     "access": "public",

--- a/apps/create-app/src/index.ts
+++ b/apps/create-app/src/index.ts
@@ -3,69 +3,20 @@
  * SPDX-License-Identifier: MIT
  */
 
-/**
- * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
- * SPDX-License-Identifier: MIT
- */
-
 import path from 'path';
-import https from 'https';
-import http from 'http';
 import { execSync } from 'child_process';
 
-import * as tar from 'tar';
 import inquirer from 'inquirer';
-import fs from 'fs-extra';
 import { Command } from 'commander';
 import chalk from 'chalk';
+
+import { assertProjectDestinationAvailable, scaffoldProject } from './scaffold';
 
 const program = new Command();
 const args = process.argv.slice(2);
 
-const updateFlowGramVersions = (dependencies: any[], latestVersion: string) => {
-  for (const packageName in dependencies) {
-    if (packageName.startsWith('@flowgram.ai')) {
-      dependencies[packageName] = latestVersion;
-    }
-  }
-};
-
-// 使用 http/https 下载文件
-function downloadFile(url: string, dest: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const lib = url.startsWith('https') ? https : http;
-
-    const file = fs.createWriteStream(dest);
-
-    const request = lib.get(url, (response) => {
-      if (response.statusCode !== 200) {
-        reject(new Error(`Download failed: ${response.statusCode}`));
-        return;
-      }
-
-      response.pipe(file);
-
-      file.on('finish', () => {
-        file.close();
-        resolve();
-      });
-    });
-
-    request.on('error', (err) => {
-      fs.unlink(dest, () => reject(err));
-    });
-
-    file.on('error', (err) => {
-      fs.unlink(dest, () => reject(err));
-    });
-  });
-}
-
 const main = async () => {
   console.log(chalk.green('Welcome to @flowgram.ai/create-app CLI!123123'));
-  const latest = execSync('npm view @flowgram.ai/demo-fixed-layout version --tag=latest latest')
-    .toString()
-    .trim();
 
   let folderName = '';
 
@@ -108,64 +59,31 @@ const main = async () => {
 
   try {
     const targetDir = path.join(process.cwd());
+    await assertProjectDestinationAvailable(targetDir, folderName);
 
-    const downloadPackage = async () => {
-      try {
-        const tempTarballPath = path.join(process.cwd(), `${folderName}.tgz`);
-        const url = `https://registry.npmjs.org/@flowgram.ai/${folderName}/-/${folderName}-${latest}.tgz`;
-
-        console.log(chalk.blue(`Downloading ${url} ...`));
-        await downloadFile(url, tempTarballPath);
-
-        fs.ensureDirSync(targetDir);
-
-        await tar.x({
-          file: tempTarballPath,
-          C: targetDir,
-        });
-
-        fs.renameSync(path.join(targetDir, 'package'), path.join(targetDir, folderName));
-        fs.unlinkSync(tempTarballPath);
-
-        return true;
-      } catch (error) {
-        console.error(`Error downloading or extracting package`);
-        console.error(error);
-        return false;
-      }
-    };
-
-    const res = await downloadPackage();
-
-    const pkgJsonPath = path.join(targetDir, folderName, 'package.json');
-    const data = fs.readFileSync(pkgJsonPath, 'utf-8');
-
+    const latest = execSync('npm view @flowgram.ai/demo-fixed-layout version --tag=latest latest')
+      .toString()
+      .trim();
     const packageLatestVersion = execSync('npm view @flowgram.ai/core version --tag=latest latest')
       .toString()
       .trim();
+    const url = `https://registry.npmjs.org/@flowgram.ai/${folderName}/-/${folderName}-${latest}.tgz`;
 
-    const jsonData = JSON.parse(data);
-    if (jsonData.dependencies) {
-      updateFlowGramVersions(jsonData.dependencies, packageLatestVersion);
-    }
+    await scaffoldProject({
+      targetDir,
+      folderName,
+      templateUrl: url,
+      flowgramVersion: packageLatestVersion,
+      onDownload: (downloadUrl) => console.log(chalk.blue(`Downloading ${downloadUrl} ...`)),
+    });
 
-    if (jsonData.devDependencies) {
-      updateFlowGramVersions(jsonData.devDependencies, packageLatestVersion);
-    }
-
-    fs.writeFileSync(pkgJsonPath, JSON.stringify(jsonData, null, 2), 'utf-8');
-
-    if (res) {
-      console.log(chalk.green(`${folderName} Demo project created successfully!`));
-      console.log(chalk.yellow('Run the following commands to start:'));
-      console.log(chalk.cyan(`  cd ${folderName}`));
-      console.log(chalk.cyan('  npm install'));
-      console.log(chalk.cyan('  npm start'));
-    } else {
-      console.log(chalk.red('Download failed'));
-    }
+    console.log(chalk.green(`${folderName} Demo project created successfully!`));
+    console.log(chalk.yellow('Run the following commands to start:'));
+    console.log(chalk.cyan(`  cd ${folderName}`));
+    console.log(chalk.cyan('  npm install'));
+    console.log(chalk.cyan('  npm start'));
   } catch (error) {
-    console.error('Error downloading repo:', error);
+    console.error('Error creating project:', error);
     return;
   }
 };

--- a/apps/create-app/src/scaffold.ts
+++ b/apps/create-app/src/scaffold.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+import { pipeline } from 'stream/promises';
+import path from 'path';
+import https from 'https';
+import http from 'http';
+
+import * as tar from 'tar';
+import fs from 'fs-extra';
+
+export interface ScaffoldProjectOptions {
+  targetDir: string;
+  folderName: string;
+  templateUrl: string;
+  flowgramVersion: string;
+  onDownload?: (url: string) => void;
+}
+
+const updateFlowGramVersions = (
+  dependencies: Record<string, string> | undefined,
+  latestVersion: string
+) => {
+  if (!dependencies) {
+    return;
+  }
+
+  for (const packageName in dependencies) {
+    if (packageName.startsWith('@flowgram.ai')) {
+      dependencies[packageName] = latestVersion;
+    }
+  }
+};
+
+export const assertProjectDestinationAvailable = async (
+  targetDir: string,
+  folderName: string
+): Promise<void> => {
+  const destinationPath = path.join(targetDir, folderName);
+
+  const destinationExists = await fs
+    .lstat(destinationPath)
+    .then(() => true)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === 'ENOENT') {
+        return false;
+      }
+      throw error;
+    });
+
+  if (destinationExists) {
+    throw new Error(`Target directory already exists: ${destinationPath}`);
+  }
+};
+
+const downloadFile = async (url: string, destination: string): Promise<void> => {
+  const response = await new Promise<http.IncomingMessage>((resolve, reject) => {
+    const client = url.startsWith('https:') ? https : http;
+    const request = client.get(url, resolve);
+    request.on('error', reject);
+  });
+
+  if (response.statusCode !== 200) {
+    response.resume();
+    throw new Error(`Download failed: ${response.statusCode}`);
+  }
+
+  await pipeline(response, fs.createWriteStream(destination));
+};
+
+export const scaffoldProject = async ({
+  targetDir,
+  folderName,
+  templateUrl,
+  flowgramVersion,
+  onDownload,
+}: ScaffoldProjectOptions): Promise<void> => {
+  const destinationPath = path.join(targetDir, folderName);
+
+  await assertProjectDestinationAvailable(targetDir, folderName);
+  await fs.ensureDir(targetDir);
+
+  const stagingPath = await fs.mkdtemp(path.join(targetDir, `.flowgram-${folderName}-`));
+  const tarballPath = `${stagingPath}.tgz`;
+  let destinationCreated = false;
+  let scaffoldFailed = false;
+  let scaffoldError: unknown;
+
+  try {
+    onDownload?.(templateUrl);
+    await downloadFile(templateUrl, tarballPath);
+    await tar.x({
+      file: tarballPath,
+      C: stagingPath,
+      strip: 1,
+    });
+
+    const packageJsonPath = path.join(stagingPath, 'package.json');
+    const packageJson = await fs.readJson(packageJsonPath);
+
+    updateFlowGramVersions(packageJson.dependencies, flowgramVersion);
+    updateFlowGramVersions(packageJson.devDependencies, flowgramVersion);
+    await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
+
+    await fs.remove(tarballPath);
+
+    try {
+      await fs.mkdir(destinationPath);
+      destinationCreated = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new Error(`Target directory already exists: ${destinationPath}`);
+      }
+      throw error;
+    }
+
+    for (const entry of await fs.readdir(stagingPath)) {
+      await fs.rename(path.join(stagingPath, entry), path.join(destinationPath, entry));
+    }
+  } catch (error) {
+    scaffoldFailed = true;
+    scaffoldError = error;
+  }
+
+  try {
+    await Promise.all([
+      fs.remove(tarballPath),
+      fs.remove(stagingPath),
+      scaffoldFailed && destinationCreated ? fs.remove(destinationPath) : Promise.resolve(),
+    ]);
+  } catch (cleanupError) {
+    if (scaffoldFailed) {
+      const scaffoldMessage =
+        scaffoldError instanceof Error ? scaffoldError.message : String(scaffoldError);
+      const cleanupMessage =
+        cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      throw new Error(
+        `Project creation failed (${scaffoldMessage}) and temporary files could not be removed (${cleanupMessage})`
+      );
+    }
+    throw cleanupError;
+  }
+
+  if (scaffoldFailed) {
+    throw scaffoldError;
+  }
+};

--- a/apps/create-app/tests/scaffold.test.ts
+++ b/apps/create-app/tests/scaffold.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+ * SPDX-License-Identifier: MIT
+ */
+
+import path from 'path';
+import os from 'os';
+import http from 'http';
+
+import { afterEach, describe, expect, it } from 'vitest';
+import * as tar from 'tar';
+import fs from 'fs-extra';
+
+import { scaffoldProject } from '../src/scaffold';
+
+const temporaryRoots: string[] = [];
+const servers: http.Server[] = [];
+const releaseResponses: Array<() => void> = [];
+
+const createTemporaryRoot = async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'flowgram-create-app-test-'));
+  temporaryRoots.push(root);
+  return root;
+};
+
+const createTemplateTarball = async (root: string, includePackageJson = true) => {
+  const fixtureDir = path.join(root, 'fixture');
+  const packageDir = path.join(fixtureDir, 'package');
+  const tarballPath = path.join(root, 'template.tgz');
+
+  await fs.ensureDir(packageDir);
+  if (includePackageJson) {
+    await fs.writeJson(
+      path.join(packageDir, 'package.json'),
+      {
+        name: 'flowgram-template',
+        dependencies: {
+          '@flowgram.ai/core': '0.0.1',
+          react: '^18.0.0',
+        },
+        devDependencies: {
+          '@flowgram.ai/eslint-config': '0.0.1',
+        },
+      },
+      { spaces: 2 }
+    );
+  }
+  await fs.writeFile(path.join(packageDir, 'README.md'), '# Template\n');
+  await tar.c({ gzip: true, cwd: fixtureDir, file: tarballPath }, ['package']);
+
+  return tarballPath;
+};
+
+const serveFile = async (filePath: string, statusCode = 200) => {
+  let requestCount = 0;
+  const server = http.createServer((_request, response) => {
+    requestCount += 1;
+    response.statusCode = statusCode;
+    if (statusCode !== 200) {
+      response.end('fixture download failed');
+      return;
+    }
+    fs.createReadStream(filePath).pipe(response);
+  });
+  servers.push(server);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to start fixture server');
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/template.tgz`,
+    getRequestCount: () => requestCount,
+  };
+};
+
+const serveFileAfterRelease = async (filePath: string) => {
+  let releaseResponse: () => void = () => undefined;
+  let markRequested: () => void = () => undefined;
+  const released = new Promise<void>((resolve) => {
+    releaseResponse = resolve;
+  });
+  releaseResponses.push(() => releaseResponse());
+  const requested = new Promise<void>((resolve) => {
+    markRequested = resolve;
+  });
+  const server = http.createServer(async (_request, response) => {
+    markRequested();
+    await released;
+    fs.createReadStream(filePath).pipe(response);
+  });
+  servers.push(server);
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to start fixture server');
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}/template.tgz`,
+    waitForRequest: () => requested,
+    release: releaseResponse,
+  };
+};
+
+afterEach(async () => {
+  releaseResponses.splice(0).forEach((release) => release());
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        })
+    )
+  );
+  await Promise.all(temporaryRoots.splice(0).map((root) => fs.remove(root)));
+});
+
+describe('scaffoldProject', () => {
+  it('leaves an existing project unchanged and does not download', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const destination = path.join(workDir, 'demo-free-layout');
+    const packageJsonPath = path.join(destination, 'package.json');
+    const originalPackageJson = `${JSON.stringify(
+      {
+        name: 'existing-project',
+        dependencies: {
+          '@flowgram.ai/core': '0.1.0',
+        },
+      },
+      null,
+      2
+    )}\n`;
+    const template = await serveFile(await createTemplateTarball(root));
+
+    await fs.ensureDir(destination);
+    await fs.writeFile(packageJsonPath, originalPackageJson);
+
+    const error = await scaffoldProject({
+      targetDir: workDir,
+      folderName: 'demo-free-layout',
+      templateUrl: template.url,
+      flowgramVersion: '1.0.14',
+    }).then(
+      () => undefined,
+      (scaffoldError: unknown) => scaffoldError
+    );
+
+    await expect(fs.readFile(packageJsonPath, 'utf8')).resolves.toBe(originalPackageJson);
+    await expect(fs.readdir(workDir)).resolves.toEqual(['demo-free-layout']);
+    expect(template.getRequestCount()).toBe(0);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/already exists/i);
+  });
+
+  it('rejects a dangling destination link without downloading', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const destination = path.join(workDir, 'demo-free-layout');
+    const linkTarget = path.join(root, 'removed-project');
+    const template = await serveFile(await createTemplateTarball(root));
+
+    await fs.ensureDir(workDir);
+    await fs.ensureDir(linkTarget);
+    await fs.symlink(linkTarget, destination, process.platform === 'win32' ? 'junction' : 'dir');
+    await fs.remove(linkTarget);
+
+    await expect(
+      scaffoldProject({
+        targetDir: workDir,
+        folderName: 'demo-free-layout',
+        templateUrl: template.url,
+        flowgramVersion: '1.0.14',
+      })
+    ).rejects.toThrow(/already exists/i);
+
+    expect(template.getRequestCount()).toBe(0);
+    expect((await fs.lstat(destination)).isSymbolicLink()).toBe(true);
+    await expect(fs.readdir(workDir)).resolves.toEqual(['demo-free-layout']);
+  });
+
+  it('preserves an empty destination created while the template downloads', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const destination = path.join(workDir, 'demo-free-layout');
+    const template = await serveFileAfterRelease(await createTemplateTarball(root));
+
+    await fs.ensureDir(workDir);
+    const scaffoldPromise = scaffoldProject({
+      targetDir: workDir,
+      folderName: 'demo-free-layout',
+      templateUrl: template.url,
+      flowgramVersion: '1.0.14',
+    });
+
+    await template.waitForRequest();
+    await fs.ensureDir(destination);
+    template.release();
+
+    await expect(scaffoldPromise).rejects.toThrow(/already exists/i);
+    await expect(fs.readdir(destination)).resolves.toEqual([]);
+    await expect(fs.readdir(workDir)).resolves.toEqual(['demo-free-layout']);
+  });
+
+  it('preserves a populated destination created while the template downloads', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const destination = path.join(workDir, 'demo-free-layout');
+    const sentinelPath = path.join(destination, 'sentinel.txt');
+    const template = await serveFileAfterRelease(await createTemplateTarball(root));
+
+    await fs.ensureDir(workDir);
+    const scaffoldPromise = scaffoldProject({
+      targetDir: workDir,
+      folderName: 'demo-free-layout',
+      templateUrl: template.url,
+      flowgramVersion: '1.0.14',
+    });
+
+    await template.waitForRequest();
+    await fs.ensureDir(destination);
+    await fs.writeFile(sentinelPath, 'existing');
+    template.release();
+
+    await expect(scaffoldPromise).rejects.toThrow(/already exists/i);
+    await expect(fs.readFile(sentinelPath, 'utf8')).resolves.toBe('existing');
+    await expect(fs.readdir(workDir)).resolves.toEqual(['demo-free-layout']);
+  });
+
+  it('removes temporary files when a callback throws a falsey value', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const template = await serveFile(await createTemplateTarball(root));
+    let rejected = false;
+    let rejection: unknown;
+
+    await fs.ensureDir(workDir);
+    try {
+      await scaffoldProject({
+        targetDir: workDir,
+        folderName: 'demo-free-layout',
+        templateUrl: template.url,
+        flowgramVersion: '1.0.14',
+        onDownload: () => {
+          throw undefined;
+        },
+      });
+    } catch (error) {
+      rejected = true;
+      rejection = error;
+    }
+
+    expect(rejected).toBe(true);
+    expect(rejection).toBeUndefined();
+    expect(template.getRequestCount()).toBe(0);
+    await expect(fs.readdir(workDir)).resolves.toEqual([]);
+  });
+
+  it('removes temporary files after download fails', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const fixturePath = path.join(root, 'error.txt');
+
+    await fs.ensureDir(workDir);
+    await fs.writeFile(fixturePath, 'failed');
+    const template = await serveFile(fixturePath, 503);
+
+    await expect(
+      scaffoldProject({
+        targetDir: workDir,
+        folderName: 'demo-free-layout',
+        templateUrl: template.url,
+        flowgramVersion: '1.0.14',
+      })
+    ).rejects.toThrow('Download failed: 503');
+
+    await expect(fs.readdir(workDir)).resolves.toEqual([]);
+  });
+
+  it('removes downloaded and partially extracted files after extraction fails', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const invalidTarballPath = path.join(root, 'invalid.tgz');
+
+    await fs.ensureDir(workDir);
+    await fs.writeFile(invalidTarballPath, 'not a tarball');
+    const template = await serveFile(invalidTarballPath);
+
+    await expect(
+      scaffoldProject({
+        targetDir: workDir,
+        folderName: 'demo-free-layout',
+        templateUrl: template.url,
+        flowgramVersion: '1.0.14',
+      })
+    ).rejects.toThrow();
+
+    await expect(fs.readdir(workDir)).resolves.toEqual([]);
+  });
+
+  it('removes extracted files when project preparation fails', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const template = await serveFile(await createTemplateTarball(root, false));
+
+    await fs.ensureDir(workDir);
+    await expect(
+      scaffoldProject({
+        targetDir: workDir,
+        folderName: 'demo-free-layout',
+        templateUrl: template.url,
+        flowgramVersion: '1.0.14',
+      })
+    ).rejects.toThrow();
+
+    await expect(fs.readdir(workDir)).resolves.toEqual([]);
+  });
+
+  it('publishes a fully prepared project without temporary artifacts', async () => {
+    const root = await createTemporaryRoot();
+    const workDir = path.join(root, 'work');
+    const template = await serveFile(await createTemplateTarball(root));
+
+    await fs.ensureDir(workDir);
+    await scaffoldProject({
+      targetDir: workDir,
+      folderName: 'demo-free-layout',
+      templateUrl: template.url,
+      flowgramVersion: '1.0.14',
+    });
+
+    const packageJson = await fs.readJson(path.join(workDir, 'demo-free-layout', 'package.json'));
+    expect(packageJson.dependencies).toEqual({
+      '@flowgram.ai/core': '1.0.14',
+      react: '^18.0.0',
+    });
+    expect(packageJson.devDependencies).toEqual({
+      '@flowgram.ai/eslint-config': '1.0.14',
+    });
+    await expect(fs.readdir(workDir)).resolves.toEqual(['demo-free-layout']);
+  });
+});

--- a/apps/create-app/tsconfig.json
+++ b/apps/create-app/tsconfig.json
@@ -16,5 +16,5 @@
     "jsx": "react-jsx",
     "lib": ["es6", "dom", "es2020", "es2019.Array"]
   },
-  "include": ["./src"],
+  "include": ["./src", "./tests"]
 }

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   ../../apps/cli:
     dependencies:
+      '@flowgram.ai/create-app':
+        specifier: workspace:*
+        version: link:../create-app
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -92,6 +95,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.0.0
         version: 8.43.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@18.19.124)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.19.4)(yaml@2.8.1))
       eslint:
         specifier: ^9.0.0
         version: 9.39.2(jiti@2.6.1)
@@ -101,6 +107,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@18.19.124)(jiti@2.6.1)(jsdom@26.1.0)(less@4.4.1)(lightningcss@1.30.1)(sass-embedded@1.93.2)(sass@1.93.2)(terser@5.44.0)(tsx@4.19.4)(yaml@2.8.1)
 
   ../../apps/demo-fixed-layout:
     dependencies:


### PR DESCRIPTION
## Summary

- fail before npm metadata lookup or template download when the selected project path already exists
- share one failure-safe scaffolding implementation between `@flowgram.ai/create-app` and `@flowgram.ai/cli`
- download, extract, and rewrite FlowGram dependency versions in an isolated staging directory
- atomically claim the absent destination with a non-recursive `mkdir`, then clean the tarball, staging tree, and any destination owned by the failed attempt
- add filesystem regressions for existing paths, dangling links, empty and populated destination races, falsey thrown values, download/extraction/preparation failures, and the successful path

## Behavior choice

An existing destination already made the old flow fail during `renameSync`. This keeps that no-overwrite outcome, but moves it before npm/network work and prevents the failed command from rewriting the existing project's `package.json` or leaving extraction artifacts behind.

The final destination claim uses `mkdir` rather than a check-then-rename sequence, so a concurrently created empty directory is not replaced on POSIX filesystems.

The npm query syntax is intentionally unchanged; the separate command cleanup in #1136 remains independent of this fix.

## Validation

- `rush build`
- `rush lint --verbose`
- `rush ts-check`
- `rush test:cov`
- Node.js 18.20.8: 9/9 `@flowgram.ai/create-app` regression tests
- Node.js 18.20.8: live registry scaffolding through both public entry points, with all 15 FlowGram dependencies rewritten to `1.0.14`
- Node.js 18.20.8: both public entry points preserve an existing sentinel and do not invoke npm
- ESM and CJS `@flowgram.ai/create-app/scaffold` subpath imports
- `npm pack --dry-run --json` confirms the scaffold ESM/CJS/type outputs are published and tests are excluded

Fixes #1172

## AI assistance

I used an AI coding assistant during implementation and testing. I reviewed the complete diff and validation results and take responsibility for the change.
