### PR TITLE
docs(materials): complete TypeSelector custom type section

### DIFF
--- a/apps/docs/src/en/materials/components/type-selector.mdx
+++ b/apps/docs/src/en/materials/components/type-selector.mdx
@@ -10,6 +10,10 @@ TypeSelector is a type selector component used for selecting JSON Schema types i
   <img loading="lazy" src="/materials/type-selector.png" alt="TypeSelector Component" style={{ width: '50%' }} />
 </div>
 
+:::tip
+If you want to add new variable types, please read [Type Management](../common/json-schema-preset)
+:::
+
 ## Demo
 
 ### Basic Usage
@@ -32,6 +36,16 @@ const formMeta = {
   ),
 }
 ```
+
+### Adding a Custom Type
+
+See [Type Management](../common/json-schema-preset).
+
+After you register a custom type with `createTypePresetPlugin`, `TypeSelector` reads the type registry through `useTypeManager()` and shows the new type in the cascader. Minimal steps:
+
+1. Add `createTypePresetPlugin({ types: [...] })` to the editor `plugins` (provide `type`, `icon`, `label`, `ConstantRenderer`, etc.).
+2. Open a form that uses `TypeSelector` and confirm the new type appears in the options.
+3. See the Type Management guide for the full Color example and API reference.
 
 ## API Reference
 

--- a/apps/docs/src/zh/materials/components/type-selector.mdx
+++ b/apps/docs/src/zh/materials/components/type-selector.mdx
@@ -39,8 +39,13 @@ const formMeta = {
 
 ### 新增新类型
 
-详见：
+详见：[类型管理](../common/json-schema-preset)。
 
+通过 `createTypePresetPlugin` 注册自定义类型后，`TypeSelector` 会经由 `useTypeManager()` 读取类型注册表，并自动出现在级联选项中。最小步骤：
+
+1. 在编辑器 `plugins` 中调用 `createTypePresetPlugin({ types: [...] })` 注册类型（提供 `type` / `icon` / `label` / `ConstantRenderer` 等）。
+2. 打开包含 `TypeSelector` 的表单，确认新类型已出现在选项列表中。
+3. Color 完整示例与 API 说明见上方类型管理文档。
 
 ## API 参考
 


### PR DESCRIPTION
## Summary
- Fill the incomplete Chinese「新增新类型」section in TypeSelector docs
- Add the matching English「Adding a Custom Type」section and tip link to Type Management

## Why
Issue #494 asks contributors to complete WIP materials docs. The TypeSelector ZH guide had an empty「详见：」section; EN lacked the counterpart.

## Test plan
- [ ] Review ZH/EN TypeSelector pages for consistent structure with other materials docs
- [ ] Confirm links to `../common/json-schema-preset` resolve

Related to #494