### PR TITLE
docs(runtime): align guides with published packages and TaskReport shape

### DIFF
--- a/apps/docs/src/en/guide/runtime/api.mdx
+++ b/apps/docs/src/en/guide/runtime/api.mdx
@@ -163,25 +163,27 @@ TaskReport API returns a `TaskReportOutput` object containing the execution repo
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| workflow | WorkflowStatus | Overall status of the workflow |
-| nodes | `Record<string, NodeStatus>` | Execution status of each node |
+| id | string | Task ID |
+| inputs | object | Workflow inputs captured for the task |
+| outputs | object | Workflow outputs (may be empty while running) |
+| workflowStatus | StatusData | Overall workflow status |
+| reports | `Record<string, NodeReport>` | Per-node status and snapshots |
+| messages | object | Runtime messages collected during execution |
 
-The `WorkflowStatus` structure is as follows:
+The `StatusData` / node report shape is as follows:
 
 ```typescript
-interface WorkflowStatus {
-  status: 'idle' | 'processing' | 'success' | 'fail' | 'canceled';
+interface StatusData {
+  status: 'pending' | 'processing' | 'succeeded' | 'failed' | 'canceled';
   terminated: boolean;
-}
-```
-
-The `NodeStatus` structure is as follows:
-
-```typescript
-interface NodeStatus {
-  status: 'idle' | 'processing' | 'success' | 'fail' | 'canceled';
-  startTime?: number;
+  startTime: number;
   endTime?: number;
+  timeCost: number;
+}
+
+interface NodeReport extends StatusData {
+  id: string;
+  snapshots: unknown[];
 }
 ```
 
@@ -206,11 +208,11 @@ async function getTaskReport(taskID) {
       return;
     }
 
-    console.log('Workflow status:', report.workflow.status);
-    console.log('Workflow terminated:', report.workflow.terminated);
+    console.log('Workflow status:', report.workflowStatus.status);
+    console.log('Workflow terminated:', report.workflowStatus.terminated);
 
     // Print status of each node
-    for (const [nodeId, nodeStatus] of Object.entries(report.nodes)) {
+    for (const [nodeId, nodeStatus] of Object.entries(report.reports)) {
       console.log(`Node ${nodeId} status:`, nodeStatus.status);
       if (nodeStatus.startTime) {
         console.log(`Node ${nodeId} start time:`, new Date(nodeStatus.startTime).toLocaleString());
@@ -230,8 +232,8 @@ async function getTaskReport(taskID) {
 ### Notes
 
 - The task report is real-time, you can call TaskReport API multiple times to get the latest execution status
-- If the workflow has not terminated (`workflow.terminated` is false), the workflow is still executing
-- Node status can be 'idle' (not started), 'processing' (executing), 'success' (successful), 'fail' (failed), or 'canceled' (canceled)
+- If the workflow has not terminated (`workflowStatus.terminated` is false), the workflow is still executing
+- Status values are `pending`, `processing`, `succeeded`, `failed`, or `canceled`
 - It is recommended to poll the task report periodically to monitor the progress of the workflow
 
 ## TaskCancel API
@@ -261,7 +263,7 @@ TaskCancel API returns a `TaskCancelOutput` object:
 TaskCancel API may encounter the following error situations:
 
 - **Task does not exist**: When the provided taskID does not exist, returns `{ success: false }`
-- **Task already completed**: When the task has already completed or been canceled, it cannot be canceled again
+- **Task already completed**: Current implementation still returns `{ success: true }` for a stored completed task; `workflowStatus` may remain `succeeded`. Cancel-after-termination semantics are unstable until clarified.
 
 ### Usage Example
 
@@ -289,7 +291,7 @@ async function cancelTask(taskID) {
 ### Notes
 
 - Task cancellation is asynchronous, after a successful cancellation request, the task may take some time to completely stop
-- Tasks that have already completed cannot be canceled
+- Completed tasks: cancel currently returns success for stored tasks; verify final status via TaskReport
 - After canceling a task, you can check the final status of the task through TaskReport API, the status of a canceled task will change to 'canceled'
 - Canceling a task does not clear the intermediate results of the task, you can still get the results of the executed part through TaskResult API
 
@@ -355,7 +357,7 @@ async function waitForResult(taskID, pollingInterval = 1000, timeout = 60000) {
     const report = await TaskReportAPI({ taskID });
 
     // If task has terminated, get result
-    if (report && report.workflow.terminated) {
+    if (report && report.workflowStatus.terminated) {
       return await TaskResultAPI({ taskID });
     }
 

--- a/apps/docs/src/en/guide/runtime/introduction.mdx
+++ b/apps/docs/src/en/guide/runtime/introduction.mdx
@@ -23,14 +23,20 @@ FlowGram Runtime is a reference implementation of a workflow runtime engine, des
 
 ### Project Positioning and Goals
 
-FlowGram Runtime is **positioned as a demo rather than an SDK**, with the following main goals:
+FlowGram Runtime is **positioned as a reference runtime that is also published as npm packages**, with the following main goals:
 
 - Provide design and implementation reference for workflow runtimes
 - Demonstrate how to build and extend workflow engines
 - Offer code that developers can directly learn from and modify
 - Support rapid prototyping and proof of concept
 
-As a reference implementation, FlowGram Runtime will not be published as a package. Developers need to fork the repository and modify it according to their specific business scenarios and requirements.
+Published packages (early / unstable API):
+
+- @flowgram.ai/runtime-js — core JS runtime
+- @flowgram.ai/runtime-nodejs — Node.js HTTP service wrapping the runtime
+- @flowgram.ai/runtime-interface — shared API / type contracts
+
+You can install these packages for integration, or fork the repository and adapt the implementation to your business requirements.
 
 ## Core Concepts
 
@@ -63,6 +69,7 @@ Nodes are the basic execution units in a workflow, each representing a specific 
 - **LLM Node**: Calls large language models, supporting system prompts and user prompts
 - **Condition Node**: Selects different execution branches based on conditions, supporting various comparison operators
 - **Loop Node**: Performs the same operation on each element in an array, supporting sub-workflows
+- **Code / Break / Continue / HTTP Node**: Registered executors in js-core (see package source under packages/runtime/js-core/src/nodes)
 
 Each node contains ID, type, metadata, and data information, with different node types having different configuration options and behaviors.
 
@@ -135,7 +142,7 @@ Currently only JavaScript/TypeScript version is available, with plans to develop
 
 ### Feature Enhancements
 
-- Add more node types: Code, Intent, Batch, Break, Continue, HTTP.
+- Add more node types: Intent, Batch (Code, Break, Continue, and HTTP executors are already registered under packages/runtime/js-core/src/nodes).
 - Improve error handling and exception recovery mechanisms
 - Add complete server-side validation, including schema validation and input validation.
 - Support `Docker` deployment.

--- a/apps/docs/src/en/guide/runtime/quick-start.mdx
+++ b/apps/docs/src/en/guide/runtime/quick-start.mdx
@@ -10,7 +10,7 @@ This document will help you quickly get started with FlowGram Runtime, including
 
 ## Getting the Code
 
-Since FlowGram Runtime is positioned as a demo rather than an SDK and will not be published as an npm package, you need to follow these steps to obtain and use it:
+Since FlowGram Runtime is positioned as a reference runtime published as npm packages and will not be published as an npm package, you need to follow these steps to obtain and use it:
 
 ### Method 1: Fork the Repository (Recommended)
 

--- a/apps/docs/src/zh/guide/runtime/api.mdx
+++ b/apps/docs/src/zh/guide/runtime/api.mdx
@@ -163,14 +163,18 @@ TaskReport API 返回一个 `TaskReportOutput` 对象，包含任务的执行报
 
 | 字段名 | 类型 | 描述 |
 | ------ | ---- | ---- |
-| workflow | WorkflowStatus | 工作流整体状态 |
-| nodes | `Record<string, NodeStatus>` | 各节点的执行状态 |
+| id | string | 任务 ID |
+| inputs | object | 任务捕获的工作流输入 |
+| outputs | object | 工作流输出（运行中可能为空） |
+| workflowStatus | StatusData | 工作流整体状态 |
+| reports | `Record<string, NodeReport>` | 各节点状态与快照 |
+| messages | object | 运行期消息 |
 
 `WorkflowStatus` 结构如下：
 
 ```typescript
 interface WorkflowStatus {
-  status: 'idle' | 'processing' | 'success' | 'fail' | 'canceled';
+  status: 'pending' | 'processing' | 'succeeded' | 'failed' | 'canceled';
   terminated: boolean;
 }
 ```
@@ -179,7 +183,7 @@ interface WorkflowStatus {
 
 ```typescript
 interface NodeStatus {
-  status: 'idle' | 'processing' | 'success' | 'fail' | 'canceled';
+  status: 'pending' | 'processing' | 'succeeded' | 'failed' | 'canceled';
   startTime?: number;
   endTime?: number;
 }
@@ -206,11 +210,11 @@ async function getTaskReport(taskID) {
       return;
     }
 
-    console.log('工作流状态:', report.workflow.status);
-    console.log('工作流是否终止:', report.workflow.terminated);
+    console.log('工作流状态:', report.workflowStatus.status);
+    console.log('工作流是否终止:', report.workflowStatus.terminated);
 
     // 打印各节点状态
-    for (const [nodeId, nodeStatus] of Object.entries(report.nodes)) {
+    for (const [nodeId, nodeStatus] of Object.entries(report.reports)) {
       console.log(`节点 ${nodeId} 状态:`, nodeStatus.status);
       if (nodeStatus.startTime) {
         console.log(`节点 ${nodeId} 开始时间:`, new Date(nodeStatus.startTime).toLocaleString());
@@ -230,8 +234,8 @@ async function getTaskReport(taskID) {
 ### 注意事项
 
 - 任务报告是实时的，可以多次调用 TaskReport API 来获取最新的执行状态
-- 如果工作流尚未终止（`workflow.terminated` 为 false），则工作流仍在执行中
-- 节点状态可能为 'idle'（未开始）、'processing'（执行中）、'success'（成功）、'fail'（失败）或 'canceled'（已取消）
+- 如果工作流尚未终止（`workflowStatus.terminated` 为 false），则工作流仍在执行中
+- 状态值为 `pending`（未开始）、`processing`（执行中）、`succeeded`（成功）、`failed`（失败）或 `canceled`（已取消）
 - 建议定期轮询任务报告，以监控工作流的执行进度
 
 ## TaskCancel API
@@ -261,7 +265,7 @@ TaskCancel API 返回一个 `TaskCancelOutput` 对象：
 TaskCancel API 可能会遇到以下错误情况：
 
 - **任务不存在**：当提供的 taskID 不存在时，返回 `{ success: false }`
-- **任务已完成**：当任务已经完成或已经取消时，无法再次取消
+- **任务已完成**：当前实现对已存储的已完成任务仍可能返回 `{ success: true }`，`workflowStatus` 可能仍为 `succeeded`；终止后取消的语义尚不稳定，以 TaskReport 为准
 
 ### 使用示例
 
@@ -289,7 +293,7 @@ async function cancelTask(taskID) {
 ### 注意事项
 
 - 任务取消是异步的，取消请求成功后，任务可能需要一些时间才能完全停止
-- 已经完成的任务无法取消
+- 已完成任务：cancel 目前对已存储任务可能仍返回 success，请用 TaskReport 确认最终状态
 - 取消任务后，可以通过 TaskReport API 查看任务的最终状态，已取消的任务状态将变为 'canceled'
 - 取消任务不会清除任务的中间结果，仍然可以通过 TaskResult API 获取已执行部分的结果
 
@@ -355,7 +359,7 @@ async function waitForResult(taskID, pollingInterval = 1000, timeout = 60000) {
     const report = await TaskReportAPI({ taskID });
 
     // 如果任务已终止，获取结果
-    if (report && report.workflow.terminated) {
+    if (report && report.workflowStatus.terminated) {
       return await TaskResultAPI({ taskID });
     }
 

--- a/apps/docs/src/zh/guide/runtime/introduction.mdx
+++ b/apps/docs/src/zh/guide/runtime/introduction.mdx
@@ -22,14 +22,14 @@ FlowGram Runtime 是一个工作流运行时引擎的参考实现，旨在为业
 
 ### 项目定位与目标
 
-FlowGram Runtime **定位为 demo 而非 SDK**，主要目标是：
+FlowGram Runtime **定位为可参考的运行时实现，并已发布为 npm 包**，主要目标是：
 
 - 提供工作流运行时的设计和实现参考
 - 展示如何构建和扩展工作流引擎
 - 为开发者提供可以直接学习和修改的代码基础
 - 支持快速原型开发和概念验证
 
-作为参考实现，FlowGram Runtime 不会作为包发布，开发者需要 fork 代码库后，根据自己的业务场景和需求进行修改和扩展。
+已发布包（早期 / API 不稳定）：`@flowgram.ai/runtime-js`、`@flowgram.ai/runtime-nodejs`、`@flowgram.ai/runtime-interface`。你可以直接安装集成，也可以 fork 代码库后按业务场景改造扩展。
 
 ## 核心概念
 
@@ -134,7 +134,7 @@ FlowGram Runtime 的未来发展计划包括：
 ### 功能增强
 
 - 支持固定布局
-- 增加更多节点类型：代码节点、意图识别节点、批处理节点、终止循环节点、继续循环节点、HTTP节点
+- 增加更多节点类型：意图识别、批处理（代码 / Break / Continue / HTTP 执行器已在 packages/runtime/js-core/src/nodes 注册）
 - 完善错误处理和异常恢复机制
 - 完善的服务端校验接口，包括 schema 校验和输入校验等
 - 支持 `Docker` 运行

--- a/apps/docs/src/zh/guide/runtime/quick-start.mdx
+++ b/apps/docs/src/zh/guide/runtime/quick-start.mdx
@@ -10,7 +10,7 @@ sidebar_position: 3
 
 ## 获取代码
 
-由于 FlowGram Runtime 定位为 demo 而非 SDK，不会作为 npm 包发布，您需要通过以下步骤来获取和使用：
+FlowGram Runtime 已发布 npm 包（`@flowgram.ai/runtime-js` / `@flowgram.ai/runtime-nodejs`）。若要从源码调试或二次开发，可通过以下步骤获取仓库：
 
 ### 方式一：Fork 仓库（推荐）
 


### PR DESCRIPTION
## Summary
- Document published npm packages (`runtime-js` / `runtime-nodejs` / `runtime-interface`)
- Note Code/Break/Continue/HTTP executors already registered in js-core
- Align TaskReport fields/status enum with `@flowgram.ai/runtime-interface`
- Document observed cancel-after-completion behavior without changing API semantics

## Test plan
- [ ] Spot-check EN/ZH introduction + api pages
- [ ] Confirm package names match npm registry
- [ ] Confirm status enum matches `WorkflowStatus` in interface package

Fixes #1174