### PR TITLE
fix(free-lines): let clicks pass through line bounding boxes

### DIFF
--- a/packages/plugins/free-lines-plugin/src/components/workflow-line-render/index.style.ts
+++ b/packages/plugins/free-lines-plugin/src/components/workflow-line-render/index.style.ts
@@ -9,6 +9,16 @@ import styled from 'styled-components';
 
 export const LineStyle = styled.div`
   position: absolute;
+  /* Bounding box of a bezier can cover nodes/groups between endpoints.
+     Let clicks pass through empty SVG area; only painted stroke/fill capture events.
+     Fixes https://github.com/bytedance/flowgram.ai/issues/1008 */
+  pointer-events: none;
+
+  svg path,
+  svg polygon,
+  svg circle {
+    pointer-events: visiblePainted;
+  }
 
   @keyframes flowingDash {
     to {


### PR DESCRIPTION
## Summary
- Line wrappers use the bezier bounding box as an absolutely positioned div. When that box covers a group label, the group cannot be selected or dragged.
- Set `pointer-events: none` on the wrapper and `pointer-events: visiblePainted` on painted SVG shapes so only the line/arrow itself captures events.

Fixes #1008

## Test plan
- [ ] Free-layout demo: connect two groups so the line bbox overlaps a group title; confirm the title is still selectable/draggable
- [ ] Confirm lines and arrows are still hoverable/selectable by interacting with the stroke/arrow