### PR TITLE
fix(export): include mounted DOM size in export bounds

### DIFF
--- a/packages/plugins/export-plugin/src/export-image-service/utils.ts
+++ b/packages/plugins/export-plugin/src/export-image-service/utils.ts
@@ -4,12 +4,38 @@
  */
 
 import { FlowDocument, FlowNodeEntity } from '@flowgram.ai/document';
-import { TransformData } from '@flowgram.ai/core';
 
 const getNodesRect = (nodes: FlowNodeEntity[]) => {
   const rects = nodes
-    .map((node) => node.getData<TransformData>(TransformData)?.bounds)
-    .filter(Boolean);
+    .map((node) => {
+      const bounds = node.bounds;
+      if (!bounds) {
+        return null;
+      }
+      // Transform bounds follow meta.size; runtime UI (e.g. node logs) can
+      // grow taller/wider in the DOM and would otherwise be clipped on export.
+      const el = node.renderData?.node;
+      const mounted = Boolean(el?.parentElement);
+      const width = mounted ? Math.max(bounds.width, el!.offsetWidth) : bounds.width;
+      const height = mounted ? Math.max(bounds.height, el!.offsetHeight) : bounds.height;
+      return {
+        x: bounds.x,
+        y: bounds.y,
+        width,
+        height,
+      };
+    })
+    .filter(Boolean) as Array<{ x: number; y: number; width: number; height: number }>;
+
+  if (rects.length === 0) {
+    return {
+      width: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+    };
+  }
+
   const x1 = Math.min(...rects.map((rect) => rect.x));
   const x2 = Math.max(...rects.map((rect) => rect.x + rect.width));
   const y1 = Math.min(...rects.map((rect) => rect.y));


### PR DESCRIPTION
## Summary
`getWorkflowRect` previously used only `TransformData` / meta.size bounds, so node UI that grows beyond meta size (e.g. runtime logs) was clipped in export images.

This expands each node's export rect with `offsetWidth` / `offsetHeight` when the render node is mounted (`parentElement` present), without creating orphan DOM nodes.

Fixes #1049

## Test plan
- [ ] In `demo-free-layout`, show node runtime logs taller than the node meta size, then export PNG — logs should not be cropped
- [ ] Nodes without extra UI still export at previous bounds (+ padding)