### PR TITLE
fix(paste): remap group blockIDs and parentID on copy

### DIFF
--- a/apps/demo-free-layout/src/shortcuts/paste/unique-workflow.ts
+++ b/apps/demo-free-layout/src/shortcuts/paste/unique-workflow.ts
@@ -76,6 +76,19 @@ namespace UniqueWorkflowUtils {
     ) {
       return true;
     }
+    // group membership (data.blockIDs[]) — required when copying a loop that
+    // contains a group; otherwise pasted groups keep stale child ids (#1067)
+    if (
+      typeof node.index === 'number' &&
+      node.parent?.key === 'blockIDs' &&
+      typeof node.value === 'string'
+    ) {
+      return true;
+    }
+    // group parent pointer (data.parentID)
+    if (node?.key === 'parentID' && typeof node.value === 'string') {
+      return true;
+    }
     return false;
   };
 

--- a/apps/demo-nextjs-antd/src/editor/shortcuts/paste/unique-workflow.ts
+++ b/apps/demo-nextjs-antd/src/editor/shortcuts/paste/unique-workflow.ts
@@ -6,7 +6,7 @@
 import { customAlphabet } from 'nanoid';
 import type { WorkflowJSON, WorkflowNodeJSON } from '@flowgram.ai/free-layout-editor';
 
-import { TraverseContext, traverse } from './traverse';
+import { traverse, TraverseContext } from './traverse';
 
 namespace UniqueWorkflowUtils {
   /** generate unique id - 生成唯一ID */
@@ -74,6 +74,19 @@ namespace UniqueWorkflowUtils {
       isExist(node.container?.name) &&
       node.container?.source === 'block-output'
     ) {
+      return true;
+    }
+    // group membership (data.blockIDs[]) — required when copying a loop that
+    // contains a group; otherwise pasted groups keep stale child ids (#1067)
+    if (
+      typeof node.index === 'number' &&
+      node.parent?.key === 'blockIDs' &&
+      typeof node.value === 'string'
+    ) {
+      return true;
+    }
+    // group parent pointer (data.parentID)
+    if (node?.key === 'parentID' && typeof node.value === 'string') {
       return true;
     }
     return false;


### PR DESCRIPTION
## Summary
Copying a loop that contains a group rewrote nested node `id`s via `generateUniqueWorkflow`, but left `data.blockIDs` / `data.parentID` pointing at the originals. On paste, `buildGroupJSON` then could not re-attach children, so the duplicated group looked broken (#1067).

Also remap:
- each entry in `data.blockIDs`
- `data.parentID`

Applied in `demo-free-layout` and `demo-nextjs-antd` paste helpers.

Fixes #1067

## Test plan
- [ ] Free-layout demo: put a group inside a loop, copy the loop, paste — group membership and layout should match the original
- [ ] Copy a standalone group still works
- [ ] Edges / variable `blockID` remapping still works