### PR TITLE
fix(form-antd-materials): pass TreeSelect a scalar path value

### DIFF
--- a/packages/materials/form-antd-materials/src/components/variable-selector/index.tsx
+++ b/packages/materials/form-antd-materials/src/components/variable-selector/index.tsx
@@ -4,13 +4,14 @@
  */
 
 'use client';
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import type { TreeSelectProps, TreeNodeProps } from 'antd';
 import { DownOutlined } from '@ant-design/icons';
 
 import { IJsonSchema } from '../../typings/json-schema';
 import { useVariableTree } from './use-variable-tree';
+import { TreeNodeData } from './types';
 import { UITreeSelect } from './styles';
 
 interface TriggerRenderProps {
@@ -35,6 +36,21 @@ interface PropTypes {
 
 export type VariableSelectorProps = PropTypes;
 
+function findNodeByKey(nodes: TreeNodeData[], key: string): TreeNodeData | undefined {
+  for (const node of nodes) {
+    if (node.key === key) {
+      return node;
+    }
+    if (node.children?.length) {
+      const found = findNodeByKey(node.children, key);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}
+
 export const VariableSelector = ({
   value,
   config = {},
@@ -49,21 +65,41 @@ export const VariableSelector = ({
 }: PropTypes) => {
   const treeData = useVariableTree({ includeSchema, excludeSchema });
 
-  const onPopupScroll: TreeSelectProps['onPopupScroll'] = (e) => {
-    console.log('onPopupScroll', e);
-  };
+  // Ant Design TreeSelect is single-select by default and rejects array values.
+  // FlowGram stores variable refs as keyPath string[]; join for display like form-materials.
+  const treeValue = useMemo(() => {
+    if (!value?.length) {
+      return undefined;
+    }
+    return value.join('.');
+  }, [value]);
+
+  const handleChange = useCallback<NonNullable<TreeSelectProps['onChange']>>(
+    (next) => {
+      if (next === undefined || next === null || next === '') {
+        onChange(undefined);
+        return;
+      }
+      const key = String(next);
+      const node = findNodeByKey(treeData, key);
+      onChange(node?.keyPath ?? key.split('.'));
+    },
+    [onChange, treeData]
+  );
 
   return (
     <UITreeSelect
-      value={value}
+      value={treeValue}
+      disabled={readonly}
+      status={hasError ? 'error' : undefined}
+      placeholder={config?.placeholder}
       styles={{
         popup: { root: { maxHeight: 400, minWidth: 230, overflow: 'auto' } },
       }}
       style={style}
       treeDefaultExpandAll
-      onChange={onChange}
+      onChange={handleChange}
       treeData={treeData}
-      onPopupScroll={onPopupScroll}
       treeIcon={true}
       allowClear={allowClear}
       suffixIcon={triggerRender && value ? triggerRender({ value }) : undefined}


### PR DESCRIPTION
## Summary
`demo-nextjs-antd` logs Ant Design warning: `value` should not be array when `TreeSelect` is single mode (`ConditionRow` → `VariableSelector`).

`@flowgram.ai/form-antd-materials` `VariableSelector` stored refs as `string[]` keyPath but passed that array straight into Ant Design `TreeSelect`. The Semi-based `@flowgram.ai/form-materials` selector already joins the path for display.

This change:
- joins `keyPath` with `.` for the TreeSelect value
- maps the selected scalar key back to `keyPath` via the tree node
- also wires `disabled` / `status` / `placeholder` for readonly and error states

Fixes #1030

## Test plan
- [ ] `apps/demo-nextjs-antd`: `bun install && bun dev`, open editor — console should no longer warn about TreeSelect array value
- [ ] Condition node: pick left/right variables; clear still works when `allowClear`
- [ ] Loop `BatchVariableSelector` still selects array variables