### PR TITLE
fix(shortcuts): allow zoom-out when canvas is zoomed in

### DIFF
--- a/apps/demo-free-layout/src/shortcuts/zoom-out/index.ts
+++ b/apps/demo-free-layout/src/shortcuts/zoom-out/index.ts
@@ -24,7 +24,9 @@ export class ZoomOutShortcut implements ShortcutsHandler {
   }
 
   public async execute(): Promise<void> {
-    if (this.playgroundConfig.zoom > 1.9) {
+    // Soft floor near minZoom (0.25); the previous `zoom > 1.9` guard was
+    // copied from zoom-in and blocked zoom-out whenever the canvas was zoomed in.
+    if (this.playgroundConfig.zoom <= 0.3) {
       return;
     }
     this.playgroundConfig.zoomout();

--- a/apps/demo-nextjs-antd/src/editor/shortcuts/zoom-out/index.ts
+++ b/apps/demo-nextjs-antd/src/editor/shortcuts/zoom-out/index.ts
@@ -24,7 +24,9 @@ export class ZoomOutShortcut implements ShortcutsHandler {
   }
 
   public async execute(): Promise<void> {
-    if (this.playgroundConfig.zoom > 1.9) {
+    // Soft floor near minZoom (0.25); the previous `zoom > 1.9` guard was
+    // copied from zoom-in and blocked zoom-out whenever the canvas was zoomed in.
+    if (this.playgroundConfig.zoom <= 0.3) {
       return;
     }
     this.playgroundConfig.zoomout();


### PR DESCRIPTION
## Summary
`ZoomOutShortcut` used the same soft guard as zoom-in (`zoom > 1.9`). After zooming in past 1.9, Ctrl/Cmd+- became a no-op even though `zoomout()` itself correctly clamps to `minZoom`.

Replace it with a soft floor near `minZoom` (0.25) so zoom-out works while zoomed in.

Applied in `demo-free-layout` and `demo-nextjs-antd`.

## Test plan
- [ ] Free-layout demo: zoom in with Ctrl/Cmd+= until near max, then Ctrl/Cmd+- repeatedly — canvas should shrink again
- [ ] Keep zooming out until near min — further zoom-out should no-op cleanly
- [ ] Same checks in demo-nextjs-antd