### PR TITLE
fix(playground): allow touch pan without hoverService (#1097)

### DIFF
--- a/packages/canvas-engine/core/src/core/layer/playground-layer.ts
+++ b/packages/canvas-engine/core/src/core/layer/playground-layer.ts
@@ -131,19 +131,18 @@ export class PlaygroundLayer extends Layer<PlaygroundLayerOptions> {
             return;
           }
           const { clientX: x, clientY: y } = MouseTouchEvent.getEventCoord(e);
-          if (!this.options?.hoverService) {
-            return;
-          }
-          this.options.hoverService.updateHoverPosition(
-            {
-              x,
-              y,
-            },
-            e.target as HTMLElement
-          );
-          const isSomeHovered = this.options.hoverService?.isSomeHovered();
-          if (isSomeHovered) {
-            return;
+          // Fixed layout has no hoverService; still allow blank-canvas touch pan (#1097).
+          if (this.options?.hoverService) {
+            this.options.hoverService.updateHoverPosition(
+              {
+                x,
+                y,
+              },
+              e.target as HTMLElement
+            );
+            if (this.options.hoverService.isSomeHovered()) {
+              return;
+            }
           }
           this.grabDragger.start(x, y);
         },


### PR DESCRIPTION
## Summary
- Fixed layout does not inject `WorkflowHoverService`.
- `PlaygroundLayer` touchstart previously returned early when `hoverService` was missing, so mobile blank-canvas drag never started.
- Skip the hover check when the service is absent; still start `grabDragger` for blank-canvas touch pan.

## Test plan
- [ ] Open fixed-layout demo on a touch device / Chrome device mode
- [ ] Drag on empty canvas background — canvas should pan
- [ ] Free-layout: dragging on a hovered node should still not pan (hoverService path unchanged)

Fixes #1097