### PR TITLE
fix(form-materials): keep loop item visible when nested enumerate lacks element type (#1077)

### DIFF
--- a/packages/materials/form-antd-materials/src/effects/provide-batch-input/index.ts
+++ b/packages/materials/form-antd-materials/src/effects/provide-batch-input/index.ts
@@ -25,6 +25,9 @@ export const provideBatchInputEffect: EffectOptions[] = createEffectFromVariable
         properties: [
           ASTFactory.createProperty({
             key: 'item',
+            // Fallback when nested EnumerateExpression cannot resolve element type (#1077).
+            // initializer.returnType still wins when the array schema is known.
+            type: ASTFactory.createCustomType({ typeName: 'unknown' }),
             initializer: ASTFactory.createEnumerateExpression({
               enumerateFor: ASTFactory.createKeyPathExpression({
                 keyPath: value.content || [],

--- a/packages/materials/form-materials/src/effects/provide-batch-input/index.ts
+++ b/packages/materials/form-materials/src/effects/provide-batch-input/index.ts
@@ -25,6 +25,9 @@ export const provideBatchInputEffect: EffectOptions[] = createEffectFromVariable
         properties: [
           ASTFactory.createProperty({
             key: 'item',
+            // Fallback when nested EnumerateExpression cannot resolve element type (#1077).
+            // initializer.returnType still wins when the array schema is known.
+            type: ASTFactory.createCustomType({ typeName: 'unknown' }),
             initializer: ASTFactory.createEnumerateExpression({
               enumerateFor: ASTFactory.createKeyPathExpression({
                 keyPath: value.content || [],


### PR DESCRIPTION
## Summary
- In nested loops, the outer `item` is often an `Array` whose `items` schema is missing.
- `EnumerateExpression` then returns `undefined`, so `Property.type` is empty and the variable tree drops `item` while `index` (explicit `Number`) remains.
- Add a `CustomType(unknown)` fallback on `item` in both `form-materials` and `form-antd-materials` `provideBatchInput`; `initializer.returnType` still wins when the schema resolves.

## Test plan
- [ ] Nested loop over a 2D array (outer items typed as array without element schema)
- [ ] Inside loop_2, variable selector should show both `item` and `index`
- [ ] When array schema has concrete element types, `item` still shows the inferred type

Fixes #1077