### PR TITLE
fix(document): respect selectable:false on dynamicSplit parents (#433)

### DIFF
--- a/packages/canvas-engine/document/src/datas/flow-node-render-data.ts
+++ b/packages/canvas-engine/document/src/datas/flow-node-render-data.ts
@@ -10,6 +10,14 @@ import { FlowNodeBaseType } from '../typings';
 import type { FlowNodeEntity } from '../entities';
 import { FlowNodeTransformData } from './index';
 
+
+function isNodeSelectable(node: FlowNodeEntity): boolean {
+  const selectable = node.getNodeMeta().selectable;
+  if (typeof selectable === 'function') {
+    return selectable(node);
+  }
+  return selectable !== false;
+}
 export interface FlowNodeRenderSchema {
   addable: boolean; // 是否可添加节点
   expandable: boolean; // 是否可展开
@@ -127,8 +135,13 @@ export class FlowNodeRenderData extends EntityData<FlowNodeRenderSchema> {
     transform.renderState.hovered = true;
 
     if (this.entity.isFirst && this.entity.parent?.id !== 'root') {
-      // 分支中第一个节点 hover，parent activated 设置为 true
-      transform.parent!.renderState.activated = true;
+      const parent = this.entity.parent!;
+      // Respect selectable:false on dynamicSplit parents (#433).
+      if (isNodeSelectable(parent)) {
+        transform.parent!.renderState.activated = true;
+      } else {
+        transform.renderState.activated = true;
+      }
     } else {
       transform.renderState.activated = true;
     }
@@ -142,7 +155,10 @@ export class FlowNodeRenderData extends EntityData<FlowNodeRenderSchema> {
       transform.renderState.hovered = false;
 
       if (this.entity.isFirst && this.entity.parent?.id !== 'root') {
-        transform.parent!.renderState.activated = false;
+        const parent = this.entity.parent!;
+        if (isNodeSelectable(parent)) {
+          transform.parent!.renderState.activated = false;
+        }
       }
       transform.renderState.activated = false;
     }, 200);
@@ -174,7 +190,13 @@ export class FlowNodeRenderData extends EntityData<FlowNodeRenderSchema> {
 
   set activated(activated: boolean) {
     if (this.entity.flowNodeType === FlowNodeBaseType.BLOCK_ICON && this.entity.parent) {
-      this.entity.parent.getData<FlowNodeRenderData>(FlowNodeRenderData)!.activated = activated;
+      const parent = this.entity.parent;
+      if (isNodeSelectable(parent)) {
+        parent.getData<FlowNodeRenderData>(FlowNodeRenderData)!.activated = activated;
+      } else if (this.data.activated !== activated) {
+        this.data.activated = activated;
+        this.fireChange();
+      }
       return;
     }
     if (this.data.activated !== activated) {

--- a/packages/canvas-engine/renderer/src/entities/flow-select-config-entity.tsx
+++ b/packages/canvas-engine/renderer/src/entities/flow-select-config-entity.tsx
@@ -13,6 +13,14 @@ import { Compare, Rectangle } from '@flowgram.ai/utils';
 
 import { findSelectedNodes } from '../utils/find-selected-nodes';
 
+
+function isNodeSelectable(node: FlowNodeEntity): boolean {
+  const selectable = node.getNodeMeta().selectable;
+  if (typeof selectable === 'function') {
+    return selectable(node);
+  }
+  return selectable !== false;
+}
 interface FlowSelectConfigEntityData {
   selectedNodes: FlowNodeEntity[];
 }
@@ -90,7 +98,12 @@ export class FlowSelectConfigEntity extends ConfigEntity<FlowSelectConfigEntityD
     transforms.forEach(transform => {
       if (Rectangle.intersects(rect, transform.bounds)) {
         if (transform.entity.originParent) {
-          selectedNodes.push(transform.entity.originParent);
+          const parent = transform.entity.originParent;
+          if (isNodeSelectable(parent)) {
+            selectedNodes.push(parent);
+          } else if (isNodeSelectable(transform.entity)) {
+            selectedNodes.push(transform.entity);
+          }
         } else {
           selectedNodes.push(transform.entity);
         }


### PR DESCRIPTION
## Summary
- dynamicSplit/condition nodes often set `selectable: false`.
- Hovering or selecting a branch child still activated the parent via `FlowNodeRenderData` and box-select always picked `originParent`.
- Gate parent activation on `isNodeSelectable`; fall back to the child when the parent is not selectable.

## Test plan
- [ ] Set `selectable: false` on a condition/dynamicSplit node
- [ ] Click/hover a child in a branch — parent should not show selected
- [ ] Box-select a child — selection should stay on the child, not the parent

Fixes #433